### PR TITLE
Drop unused ember-data dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {
     "jquery": "^1.11.1",
     "ember": "1.11.0-beta.5",
-    "ember-data": "1.0.0-beta.15",
     "ember-resolver": "~0.1.12",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "ember-cli-sass": "3.1.1",
     "ember-cli-uglify": "1.0.1",
     "ember-code-snippet": "^0.1.3",
-    "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
     "ember-try": "0.0.1",
     "glob": "4.4.0"


### PR DESCRIPTION
It's old and it generates warnings in ember-cli.