### PR TITLE
Test against 1.10 through beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,14 @@ install:
   - bower install
 
 script:
-  - ember try:testall
+  - ./node_modules/.bin/ember try "$EMBER_TRY_SCENARIO" test
+
+env:
+  - EMBER_TRY_SCENARIO="Ember 1.10.0"
+  - EMBER_TRY_SCENARIO="Ember 1.11.1"
+  - EMBER_TRY_SCENARIO="Ember Beta"
+  - EMBER_TRY_SCENARIO="Ember Canary"
+
+matrix:
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO="Ember Canary"

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,9 +1,27 @@
 module.exports = {
   scenarios: [
     {
-      name: "Ember 1.11.0-beta.5",
+      name: 'Ember Canary',
       dependencies: {
-        "ember": "1.11.0-beta.5"
+        "ember": "components/ember#canary"
+      },
+      resolutions: {
+        "ember": "canary"
+      }
+    },
+    {
+      name: 'Ember Beta',
+      dependencies: {
+        "ember": "components/ember#beta"
+      },
+      resolutions: {
+        "ember": "beta"
+      }
+    },
+    {
+      name: "Ember 1.11.1",
+      dependencies: {
+        "ember": "1.11.1"
       }
     },
     {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "ember-code-snippet": "^0.1.3",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2",
-    "ember-try": "0.0.1",
+    "ember-try": "0.0.3",
     "glob": "4.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
This enables parallel travis test runs for each of ember 1.10, 1.11, beta, and canary.

Canary is marked with `allow_failures` for now, so it is only advisory and won't cause the overall test run to fail.

