### PR TITLE
Updating ember-cli version to fix build errors on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
+    "ember-cli": "^0.2.3",
     "ember-cli-app-version": "0.3.2",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-ic-ajax": "0.1.1",


### PR DESCRIPTION
In reference to this issue: https://github.com/ember-cli/ember-cli/issues/3489. Building and serving causes an ETIMEDOUT error. Upgrading to latest to fix this.