### PR TITLE
Remove orphan overlay component

### DIFF
--- a/app/components/ember-modal-dialog-overlay.js
+++ b/app/components/ember-modal-dialog-overlay.js
@@ -1,2 +1,0 @@
-import Component from 'ember-modal-dialog/components/overlay';
-export default Component;


### PR DESCRIPTION
In 5802c696333718f7b1268d40962b8a8974c4e688, the referenced file in this component was deleted. This revision deletes the corresponding orphan file.