### PR TITLE
[Enhancement] overlayId property

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
   containerClassNamesString: computedJoin('containerClassNames'),
 
   "overlay-class": null, // set this from templates
+  overlayId: null,
   overlayClassNames: ['ember-modal-overlay'], // set this in a subclass definition
   overlayClassNamesString: computedJoin('overlayClassNames'),
 

--- a/addon/templates/components/modal-dialog.hbs
+++ b/addon/templates/components/modal-dialog.hbs
@@ -1,6 +1,6 @@
 {{#ember-wormhole to=destinationElementId}}
   {{#if hasOverlay}}
-    <div {{bind-attr class="overlayClassNamesString translucentOverlay:translucent overlay-class"}} {{action 'close'}}></div>
+    <div {{bind-attr id=overlayId class="overlayClassNamesString translucentOverlay:translucent overlay-class"}} {{action 'close'}}></div>
   {{/if}}
   {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString container-class"
                                 alignment=alignment


### PR DESCRIPTION
Thanks for open sourcing this fantastic library. Wormholes make everything better, amirite?

I'm using this as part of an ember-cli-materialize enhancement 
https://github.com/sgasser/ember-cli-materialize/pull/63

One constraint w/ this project, is we're trying to wrap an existing CSS/vanillaJS library as faithfully as possible, and it happens to use an ID instead of a class name for their modal overlay.

We already have to subclass due to the need for keybindings and uniformity of helpers, so we can solve our problem without this PR, but others who need less customization might benefit from being able to use an ID right out of the box