### PR TITLE
Add an alignment css class to the positioned div

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import template from '../templates/components/modal-dialog';
+var dasherize = Ember.String.dasherize;
 
 var computed = Ember.computed;
 var computedJoin = function(prop) {
@@ -22,6 +23,13 @@ export default Ember.Component.extend({
   overlayClassNamesString: computedJoin('overlayClassNames'),
 
   concatenatedProperties: ['containerClassNames', 'overlayClassNames'],
+
+  alignmentClass: computed('alignment', function(){
+    var alignment = this.get('alignment');
+    if (alignment) {
+      return `ember-modal-dialog-${dasherize(alignment)}`;
+    }
+  }),
 
   destinationElementId: null, // injected
   alignmentTarget: null, // view instance, passed in

--- a/addon/templates/components/modal-dialog.hbs
+++ b/addon/templates/components/modal-dialog.hbs
@@ -2,7 +2,7 @@
   {{#if hasOverlay}}
     <div {{bind-attr class="overlayClassNamesString translucentOverlay:translucent overlay-class"}} {{action 'close'}}></div>
   {{/if}}
-  {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString container-class"
+  {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString alignmentClass container-class"
                                 alignment=alignment
                                 alignmentTarget=alignmentTarget}}
     {{yield}}

--- a/tests/acceptance/modal-dialogs-test.js
+++ b/tests/acceptance/modal-dialogs-test.js
@@ -116,7 +116,10 @@ test('opening and closing modals', function(assert) {
     openSelector: '#example-alignment-target-selector button',
     dialogText: 'Alignment Target - Selector',
     closeSelector: dialogCloseButton,
-    hasOverlay: false
+    hasOverlay: false,
+    whileOpen: function(){
+      assert.ok(Ember.$(`${modalRootElementSelector} ${dialogSelector}`).hasClass('ember-modal-dialog-right'), 'has alignment class name');
+    }
   });
 
   assert.dialogOpensAndCloses({


### PR DESCRIPTION
Add a css class to the positioned div of the form `ember-modal-dialog-[alignment]`, to make applying css based on alignment easier.