### PR TITLE
Guard against `document` being undefined.

### DIFF
--- a/addon/initializers/add-modals-container.js
+++ b/addon/initializers/add-modals-container.js
@@ -1,11 +1,21 @@
-/*globals document*/
-export default function(container, application){
-  var rootEl = document.querySelector(application.rootElement);
+/*globals document */
+
+var hasDOM = typeof document !== 'undefined';
+
+function appendContainerElement(rootElementId, id) {
+  if (!hasDOM) {
+    return;
+  }
+
+  var rootEl = document.querySelector(rootElementId);
   var modalContainerEl = document.createElement('div');
+  modalContainerEl.id = id;
+  rootEl.appendChild(modalContainerEl);
+}
+
+export default function(container, application){
   var emberModalDialog = application.emberModalDialog || {};
   var modalContainerElId = emberModalDialog.modalRootElementId || 'modal-overlays';
-  modalContainerEl.id = modalContainerElId;
-  rootEl.appendChild(modalContainerEl);
 
   application.register('config:modals-container-id',
                        modalContainerElId,
@@ -14,4 +24,6 @@ export default function(container, application){
   application.inject('service:modal-dialog',
                      'destinationElementId',
                      'config:modals-container-id');
+
+  appendContainerElement(application.rootElement, modalContainerElId);
 }


### PR DESCRIPTION
Prior to adding this guard, any applications using fastboot would throw an error on application boot (because `document` is `undefined` in Node).

The modal dialog behavior in this addon will likely not work, but the application should boot.