### PR TITLE
[DO NOT MERGE] Eliminate deprecation warnings in >= 1.12

### DIFF
--- a/addon/templates/components/modal-dialog-legacy.hbs
+++ b/addon/templates/components/modal-dialog-legacy.hbs
@@ -1,6 +1,6 @@
 {{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
   {{#if hasOverlay}}
-    <div class="{{overlayClassNamesString}} {{if translucentOverlay 'translucent'}} {{overlay-class}}" {{action 'close'}}></div>
+    <div {{bind-attr class="overlayClassNamesString translucentOverlay:translucent overlay-class"}} {{action 'close'}}></div>
   {{/if}}
   {{#if useEmberTether}}
     {{#ember-tether classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,37 @@
 /* jshint node: true */
 'use strict';
+var path = require('path');
+var fs = require('fs');
+var semver = require('semver');
+var stew = require('broccoli-stew');
 
 module.exports = {
-  name: 'ember-modal-dialog'
+  name: 'ember-modal-dialog',
+  treeForAddonTemplates: function treeForAddonTemplates (tree) {
+    if (useLegacyBindingSyntax(this)) {
+      tree = stew.rm(tree, 'components/modal-dialog.hbs');
+      tree = stew.mv(tree, 'components/modal-dialog-legacy.hbs', 'components/modal-dialog.hbs');
+    } else {
+      tree = stew.rm(tree, 'components/modal-dialog-legacy.hbs');
+    }
+    return tree;
+  }
 };
+
+function useLegacyBindingSyntax(addon){
+  var emberVersion = getEmberVersion(addon);
+  if (/canary/.test(emberVersion)) { return false; }
+  if (/beta/.test(emberVersion)) { return false; }
+  if (/beta/.test(emberVersion)) { return false; }
+  return semver.lt(emberVersion, '1.13.0');
+}
+
+function getEmberVersion(addon) {
+  if (!addon.project) {
+    return null;
+  }
+
+  var bowerPath = path.join(addon.project.root, 'bower.json')
+  var bowerObj = JSON.parse(fs.readFileSync(bowerPath, 'utf8'));
+  return bowerObj.dependencies.ember;
+}

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
     "glob": "4.4.0"
   },
   "dependencies": {
+    "broccoli-stew": "^0.3.1",
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "^0.7.6",
-    "ember-wormhole": "^0.3.1"
+    "ember-wormhole": "^0.3.1",
+    "semver": "^4.3.6"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Avoid deprecations warnings by using hbs template appropriate to project's Ember version by detecting the current ember version.

- [ ] Support `ember-release` bower version (maybe by reading file for `Ember.VERSION`?)
- [ ] Fix tests on 1.13-beta and canary 