### PR TITLE
Allow 2.0.0-beta's to use current templates.

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,10 @@ module.exports = {
 
     var baseTemplatesPath = path.join(this.root, 'addon/templates');
 
-    if (dep.satisfies('>= 1.13.0')) {
-      return this.treeGenerator(path.join(baseTemplatesPath, 'current'));
-    } else {
+    if (dep.lt('1.13.0-beta.1')) {
       return this.treeGenerator(path.join(baseTemplatesPath, 'lt-1-13'));
+    } else {
+      return this.treeGenerator(path.join(baseTemplatesPath, 'current'));
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "^0.7.6",
-    "ember-cli-version-checker": "^1.1.0",
+    "ember-cli-version-checker": "^1.1.3",
     "ember-wormhole": "^0.3.1"
   },
   "keywords": [


### PR DESCRIPTION
For a few reasons the `semver.satisfies` function does not match
prelease versions in the same way as we want (it does make sense
though).

See https://github.com/npm/node-semver#prerelease-tags.

This PR switches over to use the simpler `gt`/`lt` methods which behaves
much more like what we need with prerelease versions.

A few examples using `semver.lt`:

```
> semver.lt('1.12.0-beta.1', '1.13.0')
true
> semver.lt('1.13.0-beta.1', '1.13.0')
true
> semver.lt('1.12.0', '1.13.0-beta.1')
true
> semver.lt('2.0.0', '1.13.0-beta.1')
false
> semver.lt('1.13.0', '1.13.0-beta.1')
false
> semver.lt('1.13.0-beta.1', '1.13.0-beta.1')
false
```

---

Thanks to @ef4 for pointing this out!