### PR TITLE
Nested Overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ import ModalDialog from 'ember-modal-dialog/components/modal-dialog';
 export default ModalDialog.extend({
   setup: function() {
     Ember.$('body').on('keyup.modal-dialog', (e) => {
-      if (e.keyCode == 27) {
+      if (e.keyCode === 27) {
         this.sendAction('close');
       }
     });

--- a/addon/components/modal-dialog-overlay.js
+++ b/addon/components/modal-dialog-overlay.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+
+  attributeBindings: ['data-ember-modal-dialog-overlay'],
+  'data-ember-modal-dialog-overlay': true,
+
+  // trigger only when clicking the overlay itself, not its children
+  click: function(event) {
+    if (event.target === this.get('element')) {
+      this.sendAction();
+    }
+  }
+
+});

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -32,7 +32,11 @@ export default Ember.Component.extend({
   overlayClassNames: ['ember-modal-overlay'], // set this in a subclass definition
   overlayClassNamesString: computedJoin('overlayClassNames'),
 
-  concatenatedProperties: ['containerClassNames', 'overlayClassNames'],
+  'wrapper-class': null, // set this from templates
+  wrapperClassNames: ['ember-modal-wrapper'], // set this in a subclass definition
+  wrapperClassNamesString: computedJoin('wrapperClassNames'),
+
+  concatenatedProperties: ['containerClassNames', 'overlayClassNames', 'wrapperClassNames'],
 
   alignmentClass: computed('alignment', function(){
     var alignment = this.get('alignment');
@@ -80,6 +84,7 @@ export default Ember.Component.extend({
   targetOffset: null, // passed in
 
   hasOverlay: true,
+  nestedOverlay: false,
   translucentOverlay: false,
   renderInPlace: false,
 
@@ -128,4 +133,3 @@ export default Ember.Component.extend({
     }
   }
 });
-

--- a/addon/templates/current/components/modal-dialog.hbs
+++ b/addon/templates/current/components/modal-dialog.hbs
@@ -1,25 +1,83 @@
 {{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
   {{#if hasOverlay}}
-    <div class="{{overlayClassNamesString}} {{if translucentOverlay 'translucent'}} {{overlay-class}}" {{action 'close'}} data-ember-modal-dialog-overlay></div>
-  {{/if}}
-  {{#if useEmberTether}}
-    {{#ember-tether classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
-        target=_alignmentTargetNormalized
-        attachment=_attachmentNormalized
-        targetAttachment=_targetAttachmentNormalized
-        targetModifier=_targetModifierNormalized
-        classPrefix=tetherClassPrefix
-        offset=offset
-        targetOffset=targetOffset
-    }}
-      {{yield}}
-    {{/ember-tether}}
+    {{#if nestedOverlay}}
+      <div class='{{wrapperClassNamesString}} {{wrapper-class}}'>
+        {{#ember-modal-dialog-overlay
+          classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
+          action='close'}}
+          {{#if useEmberTether}}
+            {{#ember-tether
+                classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+                target=_alignmentTargetNormalized
+                attachment=_attachmentNormalized
+                targetAttachment=_targetAttachmentNormalized
+                targetModifier=_targetModifierNormalized
+                classPrefix=tetherClassPrefix
+                offset=offset
+                targetOffset=targetOffset
+            }}
+              {{yield}}
+            {{/ember-tether}}
+          {{else}}
+            {{#ember-modal-dialog-positioned-container
+                classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+                alignment=_alignmentNormalized
+                alignmentTarget=alignmentTarget
+            }}
+              {{yield}}
+            {{/ember-modal-dialog-positioned-container}}
+          {{/if}}
+        {{/ember-modal-dialog-overlay}}
+      </div>
+    {{else}}
+      {{ember-modal-dialog-overlay
+        classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
+        action='close'}}
+        {{#if useEmberTether}}
+          {{#ember-tether
+              classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+              target=_alignmentTargetNormalized
+              attachment=_attachmentNormalized
+              targetAttachment=_targetAttachmentNormalized
+              targetModifier=_targetModifierNormalized
+              classPrefix=tetherClassPrefix
+              offset=offset
+              targetOffset=targetOffset
+          }}
+            {{yield}}
+          {{/ember-tether}}
+        {{else}}
+          {{#ember-modal-dialog-positioned-container
+              classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+              alignment=_alignmentNormalized
+              alignmentTarget=alignmentTarget
+          }}
+            {{yield}}
+          {{/ember-modal-dialog-positioned-container}}
+        {{/if}}
+    {{/if}}
   {{else}}
-    {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
-        alignment=_alignmentNormalized
-        alignmentTarget=alignmentTarget
-    }}
-      {{yield}}
-    {{/ember-modal-dialog-positioned-container}}
+    {{#if useEmberTether}}
+      {{#ember-tether
+          classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+          target=_alignmentTargetNormalized
+          attachment=_attachmentNormalized
+          targetAttachment=_targetAttachmentNormalized
+          targetModifier=_targetModifierNormalized
+          classPrefix=tetherClassPrefix
+          offset=offset
+          targetOffset=targetOffset
+      }}
+        {{yield}}
+      {{/ember-tether}}
+    {{else}}
+      {{#ember-modal-dialog-positioned-container
+          classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+          alignment=_alignmentNormalized
+          alignmentTarget=alignmentTarget
+      }}
+        {{yield}}
+      {{/ember-modal-dialog-positioned-container}}
+    {{/if}}
   {{/if}}
 {{/ember-wormhole}}

--- a/addon/templates/lt-1-13/components/modal-dialog.hbs
+++ b/addon/templates/lt-1-13/components/modal-dialog.hbs
@@ -1,25 +1,83 @@
 {{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
   {{#if hasOverlay}}
-    <div {{bind-attr class="overlayClassNamesString translucentOverlay:translucent overlay-class"}} {{action 'close'}} data-ember-modal-dialog-overlay></div>
-  {{/if}}
-  {{#if useEmberTether}}
-    {{#ember-tether classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
-        target=_alignmentTargetNormalized
-        attachment=_attachmentNormalized
-        targetAttachment=_targetAttachmentNormalized
-        targetModifier=_targetModifierNormalized
-        classPrefix=tetherClassPrefix
-        offset=offset
-        targetOffset=targetOffset
-    }}
-      {{yield}}
-    {{/ember-tether}}
+    {{#if nestedOverlay}}
+      <div {{bind-attr class='wrapperClassNamesString wrapper-class'}}>
+        {{#ember-modal-dialog-overlay
+          classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
+          action='close'}}
+          {{#if useEmberTether}}
+            {{#ember-tether
+                classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+                target=_alignmentTargetNormalized
+                attachment=_attachmentNormalized
+                targetAttachment=_targetAttachmentNormalized
+                targetModifier=_targetModifierNormalized
+                classPrefix=tetherClassPrefix
+                offset=offset
+                targetOffset=targetOffset
+            }}
+              {{yield}}
+            {{/ember-tether}}
+          {{else}}
+            {{#ember-modal-dialog-positioned-container
+                classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+                alignment=_alignmentNormalized
+                alignmentTarget=alignmentTarget
+            }}
+              {{yield}}
+            {{/ember-modal-dialog-positioned-container}}
+          {{/if}}
+        {{/ember-modal-dialog-overlay}}
+      </div>
+    {{else}}
+      {{ember-modal-dialog-overlay
+        classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
+        action='close'}}
+        {{#if useEmberTether}}
+          {{#ember-tether
+              classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+              target=_alignmentTargetNormalized
+              attachment=_attachmentNormalized
+              targetAttachment=_targetAttachmentNormalized
+              targetModifier=_targetModifierNormalized
+              classPrefix=tetherClassPrefix
+              offset=offset
+              targetOffset=targetOffset
+          }}
+            {{yield}}
+          {{/ember-tether}}
+        {{else}}
+          {{#ember-modal-dialog-positioned-container
+              classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+              alignment=_alignmentNormalized
+              alignmentTarget=alignmentTarget
+          }}
+            {{yield}}
+          {{/ember-modal-dialog-positioned-container}}
+        {{/if}}
+    {{/if}}
   {{else}}
-    {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
-        alignment=_alignmentNormalized
-        alignmentTarget=alignmentTarget
-    }}
-      {{yield}}
-    {{/ember-modal-dialog-positioned-container}}
+    {{#if useEmberTether}}
+      {{#ember-tether
+          classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+          target=_alignmentTargetNormalized
+          attachment=_attachmentNormalized
+          targetAttachment=_targetAttachmentNormalized
+          targetModifier=_targetModifierNormalized
+          classPrefix=tetherClassPrefix
+          offset=offset
+          targetOffset=targetOffset
+      }}
+        {{yield}}
+      {{/ember-tether}}
+    {{else}}
+      {{#ember-modal-dialog-positioned-container
+          classNameBindings="containerClassNamesString alignmentClass renderInPlaceClass container-class"
+          alignment=_alignmentNormalized
+          alignmentTarget=alignmentTarget
+      }}
+        {{yield}}
+      {{/ember-modal-dialog-positioned-container}}
+    {{/if}}
   {{/if}}
 {{/ember-wormhole}}

--- a/app/components/ember-modal-dialog-overlay.js
+++ b/app/components/ember-modal-dialog-overlay.js
@@ -1,0 +1,2 @@
+import Component from 'ember-modal-dialog/components/modal-dialog-overlay';
+export default Component;


### PR DESCRIPTION
Basically does two things:

1. Nests the modal within the overlay and
2. adds a wrapping div outside the modal.

This allows for the scrolling behaviour outlined in https://github.com/yapplabs/ember-modal-dialog/issues/11. It also enables Holy Grail™ centering of the modal, using the CSS quoted below.

Everything is disabled by default (to avoid breaking existing usage). It's activated via a `nestedOverlay`. Unfortunately this makes the template pretty verbose, if this could be considered breaking it would be easier.

Closes #11

Please let me know what you think! @lukemelia @samselikoff 

***

```css
.ember-modal-wrapper {
  position: fixed;
  z-index: 99;
  height: 100vh;
  left: 0;
  right: 0;
  top: 0;
  overflow-y:scroll;
}

.ember-modal-overlay {
  display:flex;
  align-items:center;
  justify-content: center;
  min-height:100vh;
  padding:1em;
}

.ember-modal-overlay.translucent {
  background-color: hsla(0, 0%, 50%, 0.25);
}

/* basic modal style (an example, this is not necessary for the centering) */
.ember-modal-dialog {
  background-color:white;
  min-width:30em;
  max-width:80vw;
  min-height:20em;
  padding:1em;
  box-sizing: border-box;
  box-shadow:0px 4px 25px 4px rgba(0,0,0,0.30);
}
```