### PR TITLE
Adds the ability to close when clicking anywhere outside the modal without an overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Property              | Purpose
 --------------------- | -------------
 `hasOverlay`          | `true|false` (default: `true`)
 `translucentOverlay`  | `true|false` (default: `false`)
+`clickOutsideToClose` | `true|false` (default: `false`) Allows you to click outside the modal to close without an overlay. Useful if your modal isn't the focus of interaction, and you want hover effects to still work outside the modal.
 `overlay-class`       | CSS class name(s) to append to overlay divs. Set this from template.`)
 `overlayClassNames`   | CSS class names to append to overlay divs. This is a concatenated property, so it does **not** replace the default overlay class (default: `'ember-modal-overlay'`. If you subclass this component, you may define this in your subclass.)
 `container-class`     | CSS class name(s) to append to container divs. Set this from template.`)

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -1,12 +1,12 @@
 import Ember from 'ember';
 import template from '../templates/components/modal-dialog';
-const dasherize = Ember.String.dasherize;
-const computed = Ember.computed;
+const { dasherize } = Ember.String;
+const { $, computed } = Ember;
 const get = Ember.get;
 var isIOS = /iPad|iPhone|iPod/.test( navigator.userAgent );
 
 const injectService = Ember.inject.service;
-const reads = Ember.computed.reads;
+const { reads } = computed;
 const computedJoin = function(prop) {
   return computed(prop, function(){
     return this.get(prop).join(' ');
@@ -81,6 +81,7 @@ export default Ember.Component.extend({
 
   hasOverlay: true,
   translucentOverlay: false,
+  clickOutsideToClose: false,
   renderInPlace: false,
 
   _attachmentNormalized: computed('alignment', 'attachment', function() {
@@ -122,6 +123,26 @@ export default Ember.Component.extend({
       Ember.$('div[data-ember-modal-dialog-overlay]').css('cursor', 'pointer');
     }
   }),
+
+  didInsertElement() {
+    if (!this.get('clickOutsideToClose')) {
+      return;
+    }
+
+    var handleClick = event => {
+      if (!$(event.target).closest('.ember-modal-dialog').length) {
+        this.send('close');
+      }
+    };
+    var registerClick = () => $(document).on('click.ember-modal-dialog', handleClick);
+
+    // setTimeout needed or else the click handler will catch the click that spawned this modal dialog
+    setTimeout(registerClick);
+  },
+  willDestroyElement() {
+    $(document).off('click.ember-modal-dialog');
+  },
+
   actions: {
     close: function() {
       this.sendAction('close');

--- a/tests/acceptance/modal-dialogs-test.js
+++ b/tests/acceptance/modal-dialogs-test.js
@@ -49,6 +49,39 @@ test('modal with translucent overlay', function(assert) {
   });
 });
 
+test('modal without overlay', function(assert) {
+  visit('/');
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: '#example-without-overlay button'
+  });
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: dialogCloseButton,
+    context: 'body'
+  });
+});
+
+test('modal without overlay click outside to close', function(assert) {
+  visit('/');
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay-click-outside-to-close button',
+    dialogText: 'Without Overlay - Click Outside to Close',
+    closeSelector: '#example-without-overlay-click-outside-to-close button'
+  });
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay-click-outside-to-close button',
+    dialogText: 'Without Overlay - Click Outside to Close',
+    closeSelector: '#example-without-overlay-click-outside-to-close'
+  });
+});
+
 test('modal with custom styles', function(assert) {
   visit('/');
 

--- a/tests/acceptance/modal-dialogs-without-tether-test.js
+++ b/tests/acceptance/modal-dialogs-without-tether-test.js
@@ -63,6 +63,38 @@ test('modal with translucent overlay', function(assert) {
   });
 });
 
+test('modal without overlay', function(assert) {
+  visit('/');
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: '#example-without-overlay button'
+  });
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: dialogCloseButton
+  });
+});
+
+test('modal without overlay click outside to close', function(assert) {
+  visit('/');
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay-click-outside-to-close button',
+    dialogText: 'Without Overlay - Click Outside to Close',
+    closeSelector: '#example-without-overlay-click-outside-to-close button'
+  });
+
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay-click-outside-to-close button',
+    dialogText: 'Without Overlay - Click Outside to Close',
+    closeSelector: '#example-without-overlay-click-outside-to-close'
+  });
+});
+
 test('modal with custom styles', function(assert) {
   visit('/');
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -3,6 +3,8 @@ import Ember from 'ember';
 export default Ember.Controller.extend({
   isShowingBasic: false,
   isShowingTranslucent: false,
+  isShowingWithoutOverlay: false,
+  isShowingWithoutOverlayClickOutsideToClose: false,
   isShowingCustomStyles: false,
   isShowingAlignmentTargetSelector: false,
   isShowingAlignmentTargetView: false,
@@ -45,6 +47,12 @@ export default Ember.Controller.extend({
     },
     toggleTranslucent: function(){
       this.toggleProperty('isShowingTranslucent');
+    },
+    toggleWithoutOverlay: function(){
+      this.toggleProperty('isShowingWithoutOverlay');
+    },
+    toggleWithoutOverlayClickOutsideToClose: function(){
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToClose');
     },
     toggleCustomStyles: function(){
       this.toggleProperty('isShowingCustomStyles');

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -33,6 +33,39 @@
   {{/if}}
 </div>
 
+<div class='example' id='example-without-overlay'>
+  <h2>Without Overlay</h2>
+  <button {{action 'toggleWithoutOverlay'}}>Do It</button>
+  {{code-snippet name='without-overlay.hbs'}}
+  {{#if isShowingWithoutOverlay}}
+    {{!-- BEGIN-SNIPPET without-overlay --}}
+    {{#modal-dialog close='toggleWithoutOverlay'
+                    hasOverlay=false}}
+      <h1>Stop! Modal Time!</h1>
+      <p>Without Overlay</p>
+      <button {{action 'toggleWithoutOverlay'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-without-overlay-click-outside-to-close'>
+  <h2>Without Overlay - Click Outside to Close</h2>
+  <button {{action 'toggleWithoutOverlayClickOutsideToClose'}}>Do It</button>
+  {{code-snippet name='without-overlay-click-outside-to-close.hbs'}}
+  {{#if isShowingWithoutOverlayClickOutsideToClose}}
+    {{!-- BEGIN-SNIPPET without-overlay-click-outside-to-close --}}
+    {{#modal-dialog close='toggleWithoutOverlayClickOutsideToClose'
+                    hasOverlay=false
+                    clickOutsideToClose=true}}
+      <h1>Stop! Modal Time!</h1>
+      <p>Without Overlay - Click Outside to Close</p>
+      <button {{action 'toggleWithoutOverlayClickOutsideToClose'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
 <div class='example' id='example-custom-styles'>
   <h2>Custom Styles</h2>
   <button {{action 'toggleCustomStyles'}}>Do It</button>

--- a/tests/helpers/modal-asserts.js
+++ b/tests/helpers/modal-asserts.js
@@ -25,7 +25,7 @@ export default function registerAssertHelpers() {
     message = message || 'Dialog triggered by ' + options.openSelector + ' failed to open and close';
     var dialogContent = [dialogSelector, ':contains(' + options.dialogText + ')'].join('');
     var self = this;
-    return click(options.openSelector).then(function() {
+    return click(options.openSelector, options.context).then(function() {
       if (options.hasOverlay) {
         self.isPresentOnce(overlaySelector);
       }
@@ -40,14 +40,14 @@ export default function registerAssertHelpers() {
         //       the horn and then disappear. This is obviously tightly coupled
         //       to arbitrary demo behavior.
         for(var i = 1; i <= 4; i++) {
-          click(options.openSelector);
+          click(options.openSelector, options.context);
         }
         andThen(function() {
           self.isAbsent(overlaySelector);
           self.isAbsent(dialogContent);
         });
       } else {
-        return click(options.closeSelector).then(function() {
+        return click(options.closeSelector, options.context).then(function() {
           self.isAbsent(overlaySelector);
           self.isAbsent(dialogContent);
         });
@@ -55,4 +55,3 @@ export default function registerAssertHelpers() {
     });
   };
 }
-


### PR DESCRIPTION
The result of #55. The use case is treating the modal as a glorified tooltip where it not necessarily the focus of attention, nor the center of the screen. Now you can have the functionality of clicking off closes, while retaining mouse effects like link hovering/clicking and other hover effects.