### PR TITLE
assert that specified alignment target exists

### DIFF
--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -31,7 +31,9 @@ export default Ember.Component.extend({
   updateAlignment: function() {
     var alignmentTarget = this.get('alignmentTarget');
     if (Ember.typeOf(alignmentTarget) === 'string') {
-      alignmentTarget = Ember.$(alignmentTarget)[0];
+      let alignmentTargetSelector = alignmentTarget;
+      alignmentTarget = Ember.$(alignmentTargetSelector)[0];
+      Ember.assert(`No element found for modal-dialog's alignmentTarget selector '${alignmentTargetSelector}'.`, alignmentTarget);
     } else if (alignmentTarget && alignmentTarget.element) {
       alignmentTarget = alignmentTarget.element;
     }


### PR DESCRIPTION
If alignmentTarget selector doesn't specify an existing element, almost certain to cause an error further down (e.g. call on undefined originOffset).  This assert  points out  the source of the problem.