### PR TITLE
Make centered scrolling example work

### DIFF
--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -93,6 +93,11 @@ $theme-color: #0f9d58;
   justify-content: center;
   min-height: 100vh;
   padding: 1em;
+
+  // reset to default (only needed in dummy, because of inheritance)
+  height:initial;
+  position:initial;
+
 }
 
 .ember-modal-overlay.translucent {
@@ -109,8 +114,7 @@ $theme-color: #0f9d58;
   box-sizing: border-box;
   box-shadow: 0px 4px 25px 4px rgba(0,0,0,0.30);
 
-  // Had to add the following two rules to make modal content scrollable
-  overflow-y: scroll;
-  height: 100vh;
+  position:initial; // reset to default (only needed in dummy, because of inheritance)
+  margin-left:50em; // cosmetics, only needed in dummy
 }
 // END-SNIPPET


### PR DESCRIPTION
Disabling overflow[1] other scrolling panes, e.g. `<body>`, will make it easier to scroll the modal, but it's no hard requirement. This is true for any situation where multiple 'layers' are scrollable.

[1] `overflow-y: hidden`