### PR TITLE
Made the initializer ember 1.13/2.0/2.1 friendly

### DIFF
--- a/addon/initializers/add-modals-container.js
+++ b/addon/initializers/add-modals-container.js
@@ -12,7 +12,8 @@ function appendContainerElement(rootElementId, id) {
   rootEl.appendChild(modalContainerEl);
 }
 
-export default function(container, application) {
+export default function() {
+  const application = arguments[1] || arguments[0];
   const emberModalDialog = application.emberModalDialog || {};
   const modalContainerElId = emberModalDialog.modalRootElementId || 'modal-overlays';
 


### PR DESCRIPTION
In ember 2.1 apps we get a dep warning about the changes to initializers. This change will support older and newer ember apps