### PR TITLE
Dynamically add/remove clickOutsideToClose handler

### DIFF
--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -7,6 +7,8 @@ const SUPPORTED_TARGET_ATTACHMENTS = [
 ];
 
 export default Ember.Component.extend({
+  attributeBindings: ['emberModalDismissId:data-ember-modal-dismiss-id'],
+  emberModalDismissId: null,
 
   // target - element selector, element, or Ember View
   // targetAttachment - top, right, bottom, left, center, or none

--- a/addon/templates/current/components/modal-dialog.hbs
+++ b/addon/templates/current/components/modal-dialog.hbs
@@ -4,7 +4,8 @@
         classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
         action='close'
     }}
-      {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString targetAttachmentClass container-class"
+      {{#ember-modal-dialog-positioned-container emberModalDismissId=emberModalDismissId
+          classNameBindings="containerClassNamesString targetAttachmentClass container-class"
           targetAttachment=targetAttachment
           target=target
       }}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-legacy-views": "0.2.0",
-    "ember-suave": "1.2.0",
+    "ember-suave": "1.2.3",
     "ember-tether": "^0.1.3",
     "ember-truth-helpers": "1.2.0",
     "ember-try": "0.0.6",

--- a/tests/index.html
+++ b/tests/index.html
@@ -32,6 +32,7 @@
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
+    <script src="assets/tests.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}


### PR DESCRIPTION
It has been my experience that some users may want to dynamically disable clickOutsideToClose. The current implementation of the clickOutsideToClose is not built to handle this.

As I saw it, there were 2 ways to implement this:
1) We could move `if (!this.get('clickOutsideToClose')) { return; }` into the click handler. This would let the click handler know the current state of `this.get('clickOutsideToClose')` but would require us to register the click handler for every instance of the modal dialog

2) Un/Reregisters the click handler when clickOutsideToClose changes

This PR:
- [x] moves the logic for adding/removing click handlers into reusable methods
- [x] adds an observer un/reregisters the click handler when clickOutsideToClose changes
- [x] updates ember-suave and the tests/index.html file so I could run the tests.
