### PR TITLE
Added clickedOverlay action

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -73,6 +73,11 @@ export default Ember.Component.extend({
   },
 
   actions: {
+    clickedOverlay() {
+      if (this.get('clickOutsideToClose')) {
+        this.sendAction('close');
+      }
+    },
     close() {
       this.sendAction('close');
     }

--- a/addon/templates/current/components/modal-dialog.hbs
+++ b/addon/templates/current/components/modal-dialog.hbs
@@ -2,7 +2,7 @@
   <div class="{{wrapperClassNamesString}} {{wrapper-class}}">
     {{#modal-dialog-overlay
         classNameBindings='overlayClassNamesString translucentOverlay:translucent overlay-class'
-        action='close'
+        action='clickedOverlay'
     }}
       {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString targetAttachmentClass container-class"
           targetAttachment=targetAttachment

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
     "ember-legacy-views": "0.2.0",
-    "ember-suave": "1.2.0",
+    "ember-suave": "1.2.3",
     "ember-tether": "^0.1.3",
     "ember-truth-helpers": "1.2.0",
     "ember-try": "0.0.6",

--- a/tests/index.html
+++ b/tests/index.html
@@ -32,6 +32,7 @@
     <script src="assets/dummy.js"></script>
     <script src="testem.js"></script>
     <script src="assets/test-loader.js"></script>
+    <script src="assets/tests.js"></script>
 
     {{content-for 'body-footer'}}
     {{content-for 'test-body-footer'}}


### PR DESCRIPTION
As per [issue 106](https://github.com/yapplabs/ember-modal-dialog/issues/106):
- [x] Added clickedOverlay action which respects the state of clickOutsideToClose
