### PR TITLE
added aria role attr to modal dialog

### DIFF
--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -15,6 +15,7 @@ export default Ember.Component.extend({
   targetAttachment: 'center',
 
   ariaRole: 'dialog',
+  attributeBindings: ['aria-labelledby', 'aria-describedby'],
 
   isPositioned: computed('targetAttachment', 'target', function() {
     if (this.get('target') && this.get('targetAttachment')) {

--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -14,6 +14,8 @@ export default Ember.Component.extend({
   //   center (relative to container)
   targetAttachment: 'center',
 
+  ariaRole: 'dialog',
+
   isPositioned: computed('targetAttachment', 'target', function() {
     if (this.get('target') && this.get('targetAttachment')) {
       return true;

--- a/tests/integration/components/modal-dialog-test.js
+++ b/tests/integration/components/modal-dialog-test.js
@@ -2,17 +2,12 @@ import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
-// Stub the modal dialog service and set the destinationElementId prop
-const modalDialogServiceStub = Ember.Service.extend({
-  destinationElementId: 'test-modal-destination'
-});
-
 moduleForComponent('modal-dialog', 'Integration | Component | modal dialog', {
   integration: true,
 
   beforeEach() {
-    this.register('service:modal-dialog', modalDialogServiceStub);
-    this.inject.service('modal-dialog', { as: 'modalService' });
+    let modalDialogService = this.container.lookup('service:modal-dialog');
+    modalDialogService.set('destinationElementId', 'test-modal-destination');
   }
 });
 

--- a/tests/integration/components/modal-dialog-test.js
+++ b/tests/integration/components/modal-dialog-test.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+// Stub the modal dialog service and set the destinationElementId prop
+const modalDialogServiceStub = Ember.Service.extend({
+  destinationElementId: 'test-modal-destination'
+});
+
+moduleForComponent('modal-dialog', 'Integration | Component | modal dialog', {
+  integration: true,
+
+  beforeEach() {
+    this.register('service:modal-dialog', modalDialogServiceStub);
+    this.inject.service('modal-dialog', { as: 'modalService' });
+  }
+});
+
+test('has aria role', function(assert) {
+  let modalDialogAriaRole;
+
+  this.render(hbs`
+    <div id="test-modal-destination"></div>
+    {{#if isShowingModalDialog}}
+      {{#modal-dialog
+        close='toggleBasic'
+        targetAttachment='none'}}
+        <h1>Stop! Modal Time!</h1>
+        <p>Should have ARIA Role!</p>
+        <button {{action 'toggleBasic'}}>Close</button>
+      {{/modal-dialog}}
+    {{/if}}
+  `);
+
+  this.set('isShowingModalDialog', true);
+
+  modalDialogAriaRole = this.$('.ember-modal-dialog').attr('role');
+
+  assert.ok(modalDialogAriaRole);
+  assert.equal(modalDialogAriaRole, 'dialog');
+});

--- a/tests/integration/components/modal-dialog-test.js
+++ b/tests/integration/components/modal-dialog-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
 
@@ -31,6 +30,5 @@ test('has aria role', function(assert) {
 
   modalDialogAriaRole = this.$('.ember-modal-dialog').attr('role');
 
-  assert.ok(modalDialogAriaRole);
   assert.equal(modalDialogAriaRole, 'dialog');
 });


### PR DESCRIPTION
Adds the aria role attribute to the ember modal dialog. 

Accessibility issues not addressed:
-  ~~`aria-labelledby` and `aria-describedby` are dependent on the id of the consumer's contents, which makes it hard to add a default value. Could possibly add a warning via `didInitAttrs` if these attributes are not provided.~~
- [focus management](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_dialog_role#Focus_management)
- the ember-tether dialog is a separate addon and the aria role should be handled there.

related to https://github.com/yapplabs/ember-modal-dialog/issues/47
