### PR TITLE
Use transform with percentages instead of explicit sizes when centering

### DIFF
--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -71,13 +71,9 @@ export default Ember.Component.extend({
   },
 
   alignCenter() {
-    const elementWidth = this.$().outerWidth();
-    const elementHeight = this.$().outerHeight();
-
     this.$().css('left', '50%')
       .css('top', '50%')
-      .css('margin-left', elementWidth * -0.5)
-      .css('margin-top', elementHeight * -0.5);
+      .css('transform', 'translate(-50%, -50%)')
   },
 
   alignLeft(targetAttachmentElement) {


### PR DESCRIPTION
Used CSS transform instead of element width and height to guarantee centering, even when modal content resizes dynamically.

This might be of some use to those being hit by #113.
