### PR TITLE
Bump ember-cli-htmlbars to 1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "1.0.3",
     "ember-cli-version-checker": "^1.1.4",
     "ember-wormhole": "^0.3.4"
   },


### PR DESCRIPTION
This may be helpful for ember-cli builds as the `broccoli-filter` dependency will be swapped out for `broccoli-persistent-filter` as recommended in ember-cli's [peformance guide](https://github.com/ember-cli/ember-cli/blob/master/PERF_GUIDE.md#a-2).