### PR TITLE
removing ember-legacy-views and all view-referencing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.0",
     "ember-export-application-global": "^1.0.3",
-    "ember-legacy-views": "0.2.0",
     "ember-suave": "1.2.3",
     "ember-tether": "^0.1.3",
     "ember-truth-helpers": "1.2.0",

--- a/tests/acceptance/modal-dialog-test.js
+++ b/tests/acceptance/modal-dialog-test.js
@@ -83,24 +83,6 @@ test('target - selector', function(assert) {
   });
 });
 
-test('target - element', function(assert) {
-  assert.dialogOpensAndCloses({
-    openSelector: '#example-target-element button',
-    dialogText: 'Target - Element',
-    closeSelector: dialogCloseButton,
-    tethered: true
-  });
-});
-
-test('target - view', function(assert) {
-  assert.dialogOpensAndCloses({
-    openSelector: '#example-target-view button',
-    dialogText: 'Target - View',
-    closeSelector: dialogCloseButton,
-    tethered: true
-  });
-});
-
 test('subclassed modal', function(assert) {
   assert.dialogOpensAndCloses({
     openSelector: '#example-subclass button',

--- a/tests/acceptance/tether-dialog-test.js
+++ b/tests/acceptance/tether-dialog-test.js
@@ -85,26 +85,6 @@ test('target - selector', function(assert) {
   });
 });
 
-test('target - element', function(assert) {
-  assert.dialogOpensAndCloses({
-    openSelector: '#example-target-element button',
-    dialogText: 'Target - Element',
-    closeSelector: dialogCloseButton,
-    hasOverlay: false,
-    tethered: true
-  });
-});
-
-test('target - view', function(assert) {
-  assert.dialogOpensAndCloses({
-    openSelector: '#example-target-view button',
-    dialogText: 'Target - View',
-    closeSelector: dialogCloseButton,
-    hasOverlay: false,
-    tethered: true
-  });
-});
-
 test('subclassed modal', function(assert) {
   assert.dialogOpensAndCloses({
     openSelector: '#example-subclass button',

--- a/tests/dummy/app/templates/-modal-dialog.hbs
+++ b/tests/dummy/app/templates/-modal-dialog.hbs
@@ -70,54 +70,6 @@
   {{/if}}
 </div>
 
-<div class='example' id='example-target-view'>
-  <h2>Target (View)</h2>
-  <div class='targetContainer'>
-    {{#view viewName="bwmdv" tagName="span"}}
-      <button {{action 'toggleTargetView'}}>Do It</button>
-    {{/view}}
-  </div>
-  {{code-snippet name='target-view-modal-dialog.hbs'}}
-  {{#if isShowingTargetView}}
-    {{!-- BEGIN-SNIPPET target-view-modal-dialog --}}
-    {{#modal-dialog close='toggleTargetView'
-                    targetAttachment=exampleTargetAttachment
-                    attachment=exampleAttachment
-                    target=view.bwmdv }}
-      <h1>Stop! Modal Time!</h1>
-      <p>Target - View: {{view.bwmdv}}</p>
-      <p>Target Attachment: {{exampleTargetAttachment}}</p>
-      <p>Attachment: {{exampleAttachment}}</p>
-      <button {{action 'closeTargetView'}}>Close</button>
-    {{/modal-dialog}}
-    {{!-- END-SNIPPET --}}
-  {{/if}}
-</div>
-
-<div class='example' id='example-target-element'>
-  <h2>Target (Element)</h2>
-  <div class='targetContainer'>
-    {{#view viewName="bwmde" tagName="span"}}
-      <button {{action 'toggleTargetElement'}}>Do It</button>
-    {{/view}}
-  </div>
-  {{code-snippet name='target-element-modal-dialog.hbs'}}
-  {{#if isShowingTargetElement}}
-    {{!-- BEGIN-SNIPPET target-element-modal-dialog --}}
-    {{#modal-dialog close='toggleTargetElement'
-                    targetAttachment=exampleTargetAttachment
-                    attachment=exampleAttachment
-                    target=view.bwmde.element }}
-      <h1>Stop! Modal Time!</h1>
-      <p>Target - Element{{view.bwmde.elementId}}</p>
-      <p>Target Attachment: {{exampleTargetAttachment}}</p>
-      <p>Attachment: {{exampleAttachment}}</p>
-      <button {{action 'closeTargetElement'}}>Close</button>
-    {{/modal-dialog}}
-    {{!-- END-SNIPPET --}}
-  {{/if}}
-</div>
-
 <div class='example' id='example-subclass'>
   <h2>Via Subclass</h2>
   <button {{action 'toggleSubclassed'}}>Do It</button>

--- a/tests/dummy/app/templates/-tether-dialog.hbs
+++ b/tests/dummy/app/templates/-tether-dialog.hbs
@@ -105,56 +105,6 @@
   {{/if}}
 </div>
 
-<div class='example' id='example-target-view'>
-  <h2>Target (View)</h2>
-  <div class='targetContainer'>
-    {{#view viewName="bwtdv" tagName="span"}}
-      <button {{action 'toggleTargetView'}}>Do It</button>
-    {{/view}}
-  </div>
-  {{code-snippet name='target-view-tether-dialog.hbs'}}
-  {{#if isShowingTargetView}}
-    {{!-- BEGIN-SNIPPET target-view-tether-dialog --}}
-    {{#tether-dialog close='toggleTargetView'
-                    hasOverlay=false
-                    targetAttachment=exampleTargetAttachment
-                    attachment=exampleAttachment
-                    target=view.bwtdv }}
-      <h1>Stop! Modal Time!</h1>
-      <p>Target - View: {{view.bwtdv}}</p>
-      <p>Target Attachment: {{exampleTargetAttachment}}</p>
-      <p>Attachment: {{exampleAttachment}}</p>
-      <button {{action 'closeTargetView'}}>Close</button>
-    {{/tether-dialog}}
-    {{!-- END-SNIPPET --}}
-  {{/if}}
-</div>
-
-<div class='example' id='example-target-element'>
-  <h2>Target (Element)</h2>
-  <div class='targetContainer'>
-    {{#view viewName="bwtde" tagName="span"}}
-      <button {{action 'toggleTargetElement'}}>Do It</button>
-    {{/view}}
-  </div>
-  {{code-snippet name='target-element-tether-dialog.hbs'}}
-  {{#if isShowingTargetElement}}
-    {{!-- BEGIN-SNIPPET target-element-tether-dialog --}}
-    {{#tether-dialog close='toggleTargetElement'
-                    hasOverlay=false
-                    targetAttachment=exampleTargetAttachment
-                    attachment=exampleAttachment
-                    target=view.bwtde.element }}
-      <h1>Stop! Modal Time!</h1>
-      <p>Target - Element{{view.bwtde.elementId}}</p>
-      <p>Target Attachment: {{exampleTargetAttachment}}</p>
-      <p>Attachment: {{exampleAttachment}}</p>
-      <button {{action 'closeTargetElement'}}>Close</button>
-    {{/tether-dialog}}
-    {{!-- END-SNIPPET --}}
-  {{/if}}
-</div>
-
 <div class='example' id='example-subclass'>
   <h2>Via Subclass</h2>
   <button {{action 'toggleSubclassed'}}>Do It</button>


### PR DESCRIPTION
Hopefully this somewhere in the right direction re: deprecated view usage, but I don't know what the planned measure of support for views is, nor if these examples should be replaced with anything else. #121 