### PR TITLE
Call `this._super.init` to avoid ember-cli deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = {
   name: 'ember-modal-dialog',
 
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
     if (!checker.for('ember-cli', 'npm').isAbove('0.2.6')) {
       console.warn("Warning: ember-modal-dialog requires ember-cli >= 0.2.6 "


### PR DESCRIPTION
This avoids the following deprecation warning:

DEPRECATION: Overriding init without calling this._super is deprecated.
Please call this._super.init && this._super.init.apply(this, arguments);