### PR TITLE
Update ember-cli-htmlbars dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "^1.0.8",
     "ember-cli-version-checker": "^1.1.4",
     "ember-wormhole": "^0.3.4"
   },


### PR DESCRIPTION
Apparently needs to be on at least 1.0.8 to resolve this deprecation warning:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-cli-htmlbars`
  at Function.Addon.lookup (/Users/dc/dev/node_modules/ember-cli/lib/models/addon.js:896:27)
```