### PR TITLE
Avoid deprecation warning by updating ember-cli-htmlbars

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.3",
-    "ember-cli-htmlbars": "1.0.3",
+    "ember-cli-htmlbars": "1.0.8",
     "ember-cli-version-checker": "^1.1.4",
     "ember-wormhole": "^0.3.4"
   },


### PR DESCRIPTION
Pre 1.0 ember-cli-htmlbars does not use _super from init in a way that Ember likes.