### PR TITLE
Support unit and integration tests out of the box.

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ import { EKMixin as EmberKeyboardMixin, keyDown } from 'ember-keyboard';
 export default ModalDialog.extend(EmberKeyboardMixin, {
   init() {
     this._super(...arguments);
-    
+
     this.set('keyboardActivated', true);
   }
 
@@ -308,7 +308,8 @@ ember install:addon ember-modal-dialog
 
 ## Unit Tests
 
-When running unit tests on components that use ember-modal-dialog it is necessary to create and register the container for ember-modal-dialog to wormhole itself into.  See this [example](tests/unit/components/component-that-uses-modal-dialog-test.js) for how to set this up in a unit test.
+When running unit tests on components that use ember-modal-dialog, modals will be
+attached to the `#ember-testing` div.
 
 ## Building
 

--- a/addon/services/modal-dialog.js
+++ b/addon/services/modal-dialog.js
@@ -1,5 +1,3 @@
 import Ember from 'ember';
 
-export default Ember.Service.extend({
-  // destinationElementId - injected
-});
+export default Ember.Service.extend();

--- a/app/services/modal-dialog.js
+++ b/app/services/modal-dialog.js
@@ -1,2 +1,21 @@
+import Ember from 'ember';
 import Service from 'ember-modal-dialog/services/modal-dialog';
-export default Service;
+import ENV from '../config/environment';
+
+const {
+  computed
+} = Ember;
+
+export default Service.extend({
+  destinationElementId: computed(function() {
+    /*
+      everywhere except test, this property will be overwritten
+      by the initializer that appends the modal container div
+      to the DOM. because initializers don't run in unit/integration
+      tests, this is a nice fallback.
+    */
+    if (ENV.environment === 'test') {
+      return 'ember-testing';
+    }
+  })
+});

--- a/tests/unit/services/modal-dialog-test.js
+++ b/tests/unit/services/modal-dialog-test.js
@@ -1,0 +1,11 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:modal-dialog', 'Unit | Service | modal dialog', {
+  // Specify the other units that are required for this test.
+  // needs: ['service:foo']
+});
+
+test('it reports ember-testing as the destinationElementId', function(assert) {
+  let service = this.subject();
+  assert.equal(service.get('destinationElementId'), 'ember-testing');
+});


### PR DESCRIPTION
This commit maintains the previous behavior where the initializer appends the destination element to the DOM, but allows for falling back to the #ember-testing div in the testing environment.

This resolves #78 and resolves #125