### PR TITLE
Yield 'this' to have access to the component for block params

### DIFF
--- a/addon/templates/current/components/modal-dialog.hbs
+++ b/addon/templates/current/components/modal-dialog.hbs
@@ -8,7 +8,7 @@
           targetAttachment=targetAttachment
           target=target
       }}
-        {{yield}}
+        {{yield this}}
       {{/ember-modal-dialog-positioned-container}}
     {{/modal-dialog-overlay}}
   </div>

--- a/addon/templates/current/components/tether-dialog.hbs
+++ b/addon/templates/current/components/tether-dialog.hbs
@@ -12,7 +12,7 @@
       target=target
       renderInPlace=renderInPlace
   }}
-    {{yield}}
+    {{yield this}}
   {{/ember-modal-dialog-positioned-container}}
 {{else}}
   {{#ember-tether classNameBindings="containerClassNamesString container-class"
@@ -25,6 +25,6 @@
       targetOffset=targetOffset
       constraints=constraints
   }}
-    {{yield}}
+    {{yield this}}
   {{/ember-tether}}
 {{/if}}


### PR DESCRIPTION
closes #151 

This can be used to enable animations, particularly exit animations. If I get the chance I'll try to make some PRs later to add animation timing and callback options. But for now this will allow users to extend the modal-dialog and tether-dialog components to implement custom animations or other methods where they need to share data from the block component to the template.

https://guides.emberjs.com/v2.8.0/components/block-params/
