### PR TITLE
Uses CSS instead of offsets for center alignment

### DIFF
--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -74,13 +74,11 @@ export default Ember.Component.extend({
   },
 
   alignCenter() {
-    const elementWidth = this.$().outerWidth();
-    const elementHeight = this.$().outerHeight();
-
-    this.$().css('left', '50%')
+    this.$().css('position', 'relative')
       .css('top', '50%')
-      .css('margin-left', elementWidth * -0.5)
-      .css('margin-top', elementHeight * -0.5);
+      .css('transform', 'translateY(-50%)')
+      .css('margin', '0 auto')
+      .css('display', 'table');
   },
 
   alignLeft(targetAttachmentElement) {


### PR DESCRIPTION
- [vertical alignment](http://zerosixthree.se/vertical-align-anything-with-just-3-lines-of-css/)
- [horizontal alignment](http://stackoverflow.com/questions/114543/horizontally-center-a-div-in-a-div)

I ran into this issue where I was having to change the content inside of a modal and it would render in weird places. This should fix that issue.