### PR TITLE
reassign app inside index.js when using nested

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,11 @@ var VersionChecker = require('ember-cli-version-checker');
 module.exports = {
   name: 'ember-modal-dialog',
 
-  init: function() {
+  init: function(app) {
+    // Needed in order to work with Ember Engines
+    if (app.app) {
+      app = app.app; 
+    }
     this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
     if (!checker.for('ember-cli', 'npm').isAbove('0.2.6')) {


### PR DESCRIPTION
The `included` hook within index.js gives a different application argument when used as a grandchild. This issue renders ember-modal-dialog useless when being used inside of an Ember Engine. This fix reassigns the application argument to the correct argument.