### PR TITLE
Check for Ember version with new ember-cli-version-checker API.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,5 +19,18 @@ module.exports = {
         + "version of ember-modal-dialog if you are stuck on an "
         + "older ember-cli.");
     }
+  },
+
+  treeForAddonTemplates: function treeForAddonTemplates (tree) {
+    var checker = new VersionChecker(this);
+    var emberVersion = checker.forEmber();
+
+    var baseTemplatesPath = path.join(this.root, 'addon/templates');
+
+    if (emberVersion.lt('1.13.0-beta.1')) {
+      return this.treeGenerator(path.join(baseTemplatesPath, 'lt-1-13'));
+    } else {
+      return this.treeGenerator(path.join(baseTemplatesPath, 'current'));
+    }
   }
 };

--- a/index.js
+++ b/index.js
@@ -11,25 +11,13 @@ module.exports = {
   init: function() {
     this._super.init && this._super.init.apply(this, arguments);
     var checker = new VersionChecker(this);
-    if (!checker.for('ember-cli', 'npm').isAbove('0.2.6')) {
+
+    if (!checker.forEmber().isAbove('0.2.6')) {
       console.warn("Warning: ember-modal-dialog requires ember-cli >= 0.2.6 "
-                   + "for support for the addon-templates tree, which allows "
-                   + "us to support various ember versions. Use an older "
-                   + "version of ember-modal-dialog if you are stuck on an "
-                   + "older ember-cli.");
-    }
-  },
-
-  treeForAddonTemplates: function treeForAddonTemplates (tree) {
-    var checker = new VersionChecker(this);
-    var dep = checker.for('ember', 'bower');
-
-    var baseTemplatesPath = path.join(this.root, 'addon/templates');
-
-    if (dep.lt('1.13.0-beta.1')) {
-      return this.treeGenerator(path.join(baseTemplatesPath, 'lt-1-13'));
-    } else {
-      return this.treeGenerator(path.join(baseTemplatesPath, 'current'));
+        + "for support for the addon-templates tree, which allows "
+        + "us to support various ember versions. Use an older "
+        + "version of ember-modal-dialog if you are stuck on an "
+        + "older ember-cli.");
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
     "ember-cli-htmlbars": "^1.0.8",
-    "ember-cli-version-checker": "^1.1.6",
+    "ember-cli-version-checker": "^1.2.0",
     "ember-wormhole": "~0.3.6"
   },
   "keywords": [


### PR DESCRIPTION
Since ember introduced the ember-source from NPM, update API usage of ember-cli-version-checker.
