### PR TITLE
[BREAKING] Change default scss to use static positioning for render in place.

### DIFF
--- a/app/styles/ember-modal-dialog/ember-modal-structure.scss
+++ b/app/styles/ember-modal-dialog/ember-modal-structure.scss
@@ -11,6 +11,6 @@
   position: fixed;
 
   &.ember-modal-dialog-in-place {
-    position: relative;
+    position: static;
   }
 }

--- a/tests/acceptance/modal-dialog-test.js
+++ b/tests/acceptance/modal-dialog-test.js
@@ -118,7 +118,7 @@ test('in place', function(assert) {
   let inPlaceSelector = [inPlaceRootSelector, inPlaceDialogSelector, `:contains(${dialogText})`].join(' ');
   let inPlaceCloseButton = [inPlaceRootSelector, inPlaceDialogSelector, 'button'].join(' ');
   andThen(function() {
-    assert.equal(Ember.$(dialogSelector).css('position'), 'relative', 'not absolutely positioned');
+    assert.equal(Ember.$(dialogSelector).css('position'), 'static', 'not absolutely positioned');
     assert.equal(Ember.$(dialogSelector).css('left'), 'auto', 'should not be positioned (left)');
     assert.equal(Ember.$(dialogSelector).css('margin-left'), '0px', 'should not be positioned (margin-left)');
     assert.isAbsent(defaultSelector);

--- a/tests/acceptance/tether-dialog-test.js
+++ b/tests/acceptance/tether-dialog-test.js
@@ -152,7 +152,7 @@ test('in place', function(assert) {
   let inPlaceSelector = [inPlaceRootSelector, inPlaceDialogSelector, `:contains(${dialogText})`].join(' ');
   let inPlaceCloseButton = [inPlaceRootSelector, inPlaceDialogSelector, 'button'].join(' ');
   andThen(function() {
-    assert.equal(Ember.$(dialogSelector).css('position'), 'relative', 'not absolutely positioned');
+    assert.equal(Ember.$(dialogSelector).css('position'), 'static', 'not absolutely positioned');
     assert.equal(Ember.$(dialogSelector).css('left'), 'auto', 'should not be positioned');
     assert.equal(Ember.$(dialogSelector).css('margin-left'), '0px', 'should not be positioned');
     assert.isAbsent(defaultSelector);


### PR DESCRIPTION
Relative was used for this, so if you were adjusting the relative positioning of your "rendered in place" modal dialog, you may need to make adjustments.