### PR TITLE
Unify `modal-dialog` and `tether-dialog` into one `modal-dialog` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,13 +80,10 @@ The modal-dialog component supports the following properties:
 Property              | Purpose
 --------------------- | -------------
 `translucentOverlay`  | Indicates translucence of overlay, toggles presence of `translucent` CSS selector
-`target`              | Element selector, element, or Ember View reference for that serves as the reference for modal position (default: `'body'`)
 `onClose`               | The action handler for the dialog's `onClose` action. This action triggers when the user clicks the modal overlay.
 `onClickOverlay`      | An action to be called when the overlay is clicked. If this action is specified, clicking the overlay will invoke it instead of `onClose`.
 `clickOutsideToClose` | Indicates whether clicking outside a modal *without* an overlay should close the modal. Useful if your modal isn't the focus of interaction, and you want hover effects to still work outside the modal.
 `renderInPlace`       | A boolean, when true renders the modal without wormholing or tethering, useful for including a modal in a style guide
-`attachment`          | A string of the form 'vert-attachment horiz-attachment', e.g. `'middle left'` (see "Positioning" section below)
-`targetAttachment`    | A string of the form 'vert-attachment horiz-attachment', e.g. `'middle left'` (see "Positioning" section below)
 `containerClass`     | CSS class name(s) to append to container divs. Set this from template.
 `containerClassNames` | CSS class names to append to container divs. This is a concatenated property, so it does **not** replace the default container class (default: `'ember-modal-dialog'`. If you subclass this component, you may define this in your subclass.)
 `overlayClass`       | CSS class name(s) to append to overlay divs. Set this from template.
@@ -94,19 +91,30 @@ Property              | Purpose
 `wrapperClass`       | CSS class name(s) to append to wrapper divs. Set this from template.
 `wrapperClassNames`   | CSS class names to append to wrapper divs. This is a concatenated property, so it does **not** replace the default container class (default: `'ember-modal-wrapper'`. If you subclass this component, you may define this in your subclass.)
 
-### tether-dialog
+The above properties of the `modal-dialog` component can be used without any additional  dependencies.
 
-The tether-dialog component supports all of the modal-dialog properties specified above as well as the following properties:
+#### Tethering
+
+If you specify a `tetherTarget`, you are opting into "tethering" behavior, and you must have either `ember-tether` or `liquid-tether` installed.
 
 Property              | Purpose
 --------------------- | -------------
-`hasOverlay`          | Toggles presence of overlay div in DOM
-`tetherClassPrefix`   | Proxies to Hubspot Tether*
-`offset`              | Proxies to Hubspot Tether*
-`targetOffset`        | Proxies to Hubspot Tether*
-`constraints`         | Proxies to Hubspot Tether*
+`tetherTarget`        | Element selector or element reference for that serves as the reference for modal position
+
+We use the amazing [Tether.js](http://tether.io/) library (via [ember-tether](https://github.com/yapplabs/ember-tether)) to let you position your dialog relative to other elements in the DOM.
 
 \* Please see [Hubspot Tether](http://github.hubspot.com/tether/) for usage documentation.
+
+When tethering scenario, you may also pass the following properties, which are passed through to Tether:
+
+Property              | Purpose
+--------------------- | -------------
+`attachment`          | Delegates to Hubspot Tether*
+`targetAttachment`    | Delegates to Hubspot Tether*
+`tetherClassPrefix`   | Delegates to Hubspot Tether*
+`offset`              | Delegates to Hubspot Tether*
+`targetOffset`        | Delegates to Hubspot Tether*
+`constraints`         | Delegates to Hubspot Tether*
 
 
 ## Which Component Should I Use?
@@ -125,9 +133,11 @@ Various modal use cases are best supported by different DOM structures. Ember Mo
 
 Ember Modal Dialog provides `attachment` and `targetAttachment` properties to configure positioning of the modal dialog near its target. To provide consistency with Hubspot Tether, Ember Modal Dialog uses the same syntax for these properties: "top|middle|bottom left|center|right|elementCenter"... e.g. `'middle left'`
 
-### Positioning tether-dialog Components
+### Positioning Your Modal Dialog
 
-The tether-dialog component uses our [ember-tether](//github.com/yapplabs/ember-tether) addon, which in turn uses [Hubspot Tether](http://github.hubspot.com/tether/). This enables modals to remain positioned near their targets when users scroll or resize the window.
+With the default SCSS provided, your modal will be centered in the viewport. By adjusting the CSS, you can adjust this logic.
+
+Pass a `tetherTarget` in order to position our modal in relation to the target and enable your modal remain positioned near their targets when users scroll or resize the window.
 
 To enable this behavior, install ember-tether as a dependency of **your ember app**.
 
@@ -149,12 +159,6 @@ Then use the tether-dialog component for any modals you wish to position this wa
 Event delegation originating from content inside ember-tether blocks will only work for Ember apps that use Ember's default root element of the `body` tag. This is because the Hubspot Tether library appends its positioned elements to the body tag.
 
 If you are not overriding the default root element, then don't worry and carry on. ember-tether will work just fine for you.
-
-### Positioning modal-dialog Components
-
-The modal-dialog component uses an internal ember-modal-dialog-positioned-container component to position modals near their targets. This is a good option if you do not wish to use Ember Tether + Hubspot Tether. Just know that this positioning logic is not nearly as sophisticated as the positioning logic in Ember Tether. That's why we made Ember Tether.
-
-NOTE: The {{ember-modal-dialog-positioned-container}} component only respects the horizontal value for `targetAttachment`. So, for example,`'top left'`, `'middle left'`, and `'bottom left'` will all be interpreted simply as `'left'`. Additionally, `'elementCenter'` will center the modal above the clicked element. We will gladly accept [PRs](https://github.com/yapplabs/ember-modal-dialog/pulls) for improvements here.
 
 ## Wormholes
 

--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -1,0 +1,96 @@
+import Ember from 'ember';
+import layout from '../templates/components/basic-dialog';
+
+const { $, computed, guidFor, inject, isEmpty } = Ember;
+const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+
+export default Ember.Component.extend({
+  tagName: '',
+  layout,
+
+  modalService: inject.service('modal-dialog'),
+  destinationElementId: computed.oneWay('modalService.destinationElementId'),
+
+  variantWrapperClass: 'emd-static',
+  containerClassNamesString: computed('containerClassNames.[]', 'targetAttachmentClass', 'attachmentClass', 'containerClass', function() {
+    return [
+      this.get('containerClassNames').join(' '),
+      this.get('targetAttachmentClass'),
+      this.get('attachmentClass'),
+      this.get('containerClass')
+    ].filter((className) => !isEmpty(className)).join(' ');
+  }),
+  overlayClassNamesString: computed('overlayClassNames.[]', 'overlayClass', 'translucentOverlay', function(){
+    return [
+      this.get('overlayClassNames').join(' '),
+      this.get('translucentOverlay') ? 'translucent' : null,
+      this.get('overlayClass')
+    ].filter((className) => !isEmpty(className)).join(' ');
+  }),
+  wrapperClassNamesString: computed('wrapperClassNames.[]', 'isCentered', 'variantWrapperClass', 'wrapperClass', function(){
+    return [
+      this.get('wrapperClassNames').join(' '),
+      this.get('isCentered') ? 'emd-centered' : null,
+      this.get('variantWrapperClass'),
+      this.get('wrapperClass')
+    ].filter((className) => !isEmpty(className)).join(' ');
+  }),
+
+  concatenatedProperties: ['containerClassNames', 'overlayClassNames', 'wrapperClassNames'],
+
+  translucentOverlay: false,
+  clickOutsideToClose: false,
+  hasOverlay: true,
+  isCentered: true,
+  overlayDOMPosition: null,
+  isOverlaySibling: computed('overlayDOMPosition', function() {
+    return this.get('overlayDOMPosition') === 'sibling';
+  }),
+
+  makeOverlayClickableOnIOS: Ember.on('didInsertElement', function() {
+    if (isIOS) {
+      Ember.$('div[data-ember-modal-dialog-overlay]').css('cursor', 'pointer');
+    }
+  }),
+
+  didInsertElement() {
+    if (!this.get('clickOutsideToClose')) {
+      return;
+    }
+
+    const handleClick = (event) => {
+      let $eventTarget = $(event.target);
+
+      // if the click has already resulted in the target
+      // being removed or hidden, do nothing
+      if (!$eventTarget.is(':visible')) {
+        return;
+      }
+
+      // if the click is within the dialog, do nothing
+      if ($eventTarget.closest('.ember-modal-dialog').length) {
+        return;
+      }
+
+      this.sendAction('onClose');
+    };
+    const registerClick = () => $(document).on(`click.ember-modal-dialog-${guidFor(this)}`, handleClick);
+
+    // setTimeout needed or else the click handler will catch the click that spawned this modal dialog
+    setTimeout(registerClick);
+
+    if (isIOS) {
+      const registerTouch = () => $(document).on(`touchend.ember-modal-dialog-${guidFor(this)}`, handleClick);
+      setTimeout(registerTouch);
+    }
+    this._super(...arguments);
+  },
+
+  willDestroyElement() {
+    $(document).off(`click.ember-modal-dialog-${guidFor(this)}`);
+    if (isIOS) {
+      $(document).off(`touchend.ember-modal-dialog-${guidFor(this)}`);
+    }
+    this._super(...arguments);
+  }
+});

--- a/addon/components/in-place-dialog.js
+++ b/addon/components/in-place-dialog.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+import layout from '../templates/components/in-place-dialog';
+
+const { computed } = Ember;
+const computedJoin = function(prop) {
+  return computed(prop, function() {
+    return this.get(prop).join(' ');
+  });
+};
+
+export default Ember.Component.extend({
+  tagName: '',
+  layout,
+
+  containerClass: null, // passed in
+  containerClassNames: ['ember-modal-dialog', 'emd-in-place'], // set this in a subclass definition
+  containerClassNamesString: computedJoin('containerClassNames'),
+
+  concatenatedProperties: ['containerClassNames']
+});

--- a/addon/components/tether-dialog.js
+++ b/addon/components/tether-dialog.js
@@ -1,12 +1,11 @@
 import Ember from 'ember';
-import ModalDialog from './modal-dialog';
+import BasicDialog from './basic-dialog';
 import layout from '../templates/components/tether-dialog';
 
 const { dasherize } = Ember.String;
-const { computed, get } = Ember;
-const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+const { computed } = Ember;
 
-export default ModalDialog.extend({
+export default BasicDialog.extend({
   layout,
 
   targetAttachmentClass: computed('targetAttachment', function() {
@@ -14,20 +13,29 @@ export default ModalDialog.extend({
     return `ember-modal-dialog-target-attachment-${dasherize(targetAttachment)}`;
   }),
 
-  targetAttachment: 'middle center',
-  attachment: 'middle center',
-  hasOverlay: true,
-  target: 'viewport', // element, css selector, view instance, 'viewport', or 'scroll-handle'
-
-  tetherClassPrefix: 'ember-tether',
+  targetAttachment: null,
+  attachment: null,
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (!this.get('attachment')) {
+      this.set('attachment', 'middle center');
+    }
+    if (!this.get('targetAttachment')) {
+      this.set('targetAttachment', 'middle center');
+    }
+  },
+  tetherTarget: null, // element, css selector, view instance, 'viewport', or 'scroll-handle'
+  tetherClassPrefix: computed({
+    get() {
+      return 'ember-tether';
+    }, set(key, val) {
+      if (val) {
+        return val;
+      }
+      return 'ember-tether';
+    }
+  }),
   // offset - passed in
   // targetOffset - passed in
   // targetModifier - passed in
-
-  makeOverlayClickableOnIOS: Ember.on('didInsertElement', function() {
-    if (isIOS && get(this, 'hasOverlay')) {
-      Ember.$('div[data-emd-overlay]').css('cursor', 'pointer');
-    }
-  })
-
 });

--- a/addon/templates/components/basic-dialog.hbs
+++ b/addon/templates/components/basic-dialog.hbs
@@ -1,0 +1,13 @@
+{{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
+  <div class={{wrapperClassNamesString}}>
+    <div class={{overlayClassNamesString}} onclick={{action (ignore-children onClickOverlay)}} tabindex="-1" data-emd-overlay>
+      {{#ember-modal-dialog-positioned-container
+          class=containerClassNamesString
+          targetAttachment=targetAttachment
+          target=legacyTarget
+      }}
+        {{yield}}
+      {{/ember-modal-dialog-positioned-container}}
+    </div>
+  </div>
+{{/ember-wormhole}}

--- a/addon/templates/components/deprecated-tether-dialog.hbs
+++ b/addon/templates/components/deprecated-tether-dialog.hbs
@@ -1,0 +1,29 @@
+{{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
+  {{#if hasOverlay}}
+    <div class={{overlayClassNamesString}} onclick={{action (action 'onClickOverlay')}} tabindex="-1" data-emd-overlay></div>
+  {{/if}}
+{{/ember-wormhole}}
+{{#if renderInPlace}}
+  {{#ember-modal-dialog-positioned-container
+      class=containerClassNamesString
+      targetAttachment=targetAttachment
+      target=target
+      renderInPlace=renderInPlace
+  }}
+    {{yield}}
+  {{/ember-modal-dialog-positioned-container}}
+{{else}}
+  {{#ember-tether
+      class=containerClassNamesString
+      target=target
+      attachment=attachment
+      targetAttachment=targetAttachment
+      targetModifier=targetModifier
+      classPrefix=tetherClassPrefix
+      offset=offset
+      targetOffset=targetOffset
+      constraints=constraints
+  }}
+    {{yield}}
+  {{/ember-tether}}
+{{/if}}

--- a/addon/templates/components/in-place-dialog.hbs
+++ b/addon/templates/components/in-place-dialog.hbs
@@ -1,0 +1,3 @@
+<div class={{concat containerClassNamesString ' ' attachmentClass ' ' containerClass}}>
+  {{yield}}
+</div>

--- a/addon/templates/components/modal-dialog.hbs
+++ b/addon/templates/components/modal-dialog.hbs
@@ -1,12 +1,29 @@
-{{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
-  <div class="{{wrapperClassNamesString}} {{wrapperClass}}">
-    <div class={{concat overlayClassNamesString ' ' (if translucentOverlay 'translucent') ' ' overlayClass}} onclick={{action (ignore-children (action 'clickedOverlay'))}} tabindex="-1" data-emd-overlay>
-      {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString targetAttachmentClass containerClass"
-          targetAttachment=targetAttachment
-          target=target
-      }}
-        {{yield}}
-      {{/ember-modal-dialog-positioned-container}}
-    </div>
-  </div>
-{{/ember-wormhole}}
+{{#component modalDialogComponentName
+    wrapperClass=wrapperClass
+    wrapperClassNames=wrapperClassNames
+    overlayClass=overlayClass
+    overlayClassNames=overlayClassNames
+    containerClass=containerClass
+    containerClassNames=containerClassNames
+    hasOverlay=hasOverlay
+    translucentOverlay=translucentOverlay
+    clickOutsideToClose=clickOutsideToClose
+    destinationElementId=destinationElementId
+
+    tetherTarget=tetherTarget
+    legacyTarget=target
+    attachment=attachment
+    targetAttachment=targetAttachment
+    targetModifier=targetModifier
+    targetOffset=targetOffset
+    offset=offset
+    tetherClassPrefix=tetherClassPrefix
+    constraints=constraints
+    attachmentClass=attachmentClass
+    targetAttachmentClass=targetAttachmentClass
+
+    onClickOverlay=(action 'onClickOverlay')
+    onClose=(action 'onClose')
+}}
+  {{yield}}
+{{/component}}

--- a/addon/templates/components/tether-dialog.hbs
+++ b/addon/templates/components/tether-dialog.hbs
@@ -1,27 +1,18 @@
-{{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
-  {{#if hasOverlay}}
-    <div class={{concat overlayClassNamesString ' ' (if translucentOverlay 'translucent') ' ' overlayClass}} onclick={{action (action 'clickedOverlay')}} tabindex="-1" data-emd-overlay></div>
-  {{/if}}
-{{/ember-wormhole}}
-{{#if renderInPlace}}
-  {{#ember-modal-dialog-positioned-container classNameBindings="containerClassNamesString targetAttachmentClass containerClass"
-      targetAttachment=targetAttachment
-      target=target
-      renderInPlace=renderInPlace
-  }}
-    {{yield}}
-  {{/ember-modal-dialog-positioned-container}}
-{{else}}
-  {{#ember-tether classNameBindings="containerClassNamesString containerClass"
-      target=target
-      attachment=attachment
-      targetAttachment=targetAttachment
-      targetModifier=targetModifier
-      classPrefix=tetherClassPrefix
-      offset=offset
-      targetOffset=targetOffset
-      constraints=constraints
-  }}
-    {{yield}}
-  {{/ember-tether}}
+{{#if hasOverlay}}
+  {{#ember-wormhole to=destinationElementId}}
+    <div class={{overlayClassNamesString}} onclick={{action onClickOverlay}} tabindex="-1" data-emd-overlay></div>
+  {{/ember-wormhole}}
 {{/if}}
+{{#ember-tether
+    class=containerClassNamesString
+    target=tetherTarget
+    attachment=attachment
+    targetAttachment=targetAttachment
+    targetModifier=targetModifier
+    classPrefix=tetherClassPrefix
+    offset=offset
+    targetOffset=targetOffset
+    constraints=constraints
+}}
+  {{yield}}
+{{/ember-tether}}

--- a/app/components/ember-modal-dialog/-basic-dialog.js
+++ b/app/components/ember-modal-dialog/-basic-dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-modal-dialog/components/basic-dialog';

--- a/app/components/ember-modal-dialog/-in-place-dialog.js
+++ b/app/components/ember-modal-dialog/-in-place-dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-modal-dialog/components/in-place-dialog';

--- a/app/components/ember-modal-dialog/-tether-dialog.js
+++ b/app/components/ember-modal-dialog/-tether-dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-modal-dialog/components/tether-dialog';

--- a/app/components/tether-dialog.js
+++ b/app/components/tether-dialog.js
@@ -1,1 +1,1 @@
-export { default } from 'ember-modal-dialog/components/tether-dialog';
+export { default } from 'ember-modal-dialog/components/deprecated-tether-dialog';

--- a/app/templates/components/modal-dialog.js
+++ b/app/templates/components/modal-dialog.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-modal-dialog/templates/components/modal-dialog';

--- a/app/templates/components/tether-dialog.js
+++ b/app/templates/components/tether-dialog.js
@@ -1,1 +1,0 @@
-export { default } from 'ember-modal-dialog/templates/components/tether-dialog';

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -10,7 +10,7 @@ const overlaySelector = '.ember-modal-overlay';
 const dialogSelector = '.ember-modal-dialog';
 const dialogCloseButton = [dialogSelector, 'button'].join(' ');
 
-module('Acceptance: Display Modal Dialogs', {
+module('Acceptance: modal-dialog | not tethered', {
   async beforeEach() {
     application = startApp();
     await visit('/');

--- a/tests/acceptance/tether-dialog-test.js
+++ b/tests/acceptance/tether-dialog-test.js
@@ -9,7 +9,7 @@ const overlaySelector = '.ember-modal-overlay';
 const dialogSelector = '.ember-modal-dialog';
 const dialogCloseButton = [dialogSelector, 'button'].join(' ');
 
-module('Acceptance: Display Tether Dialogs', {
+module('Acceptance: tether-dialog (deprecated)', {
   async beforeEach() {
     application = startApp();
     await visit('/tether-dialog');
@@ -129,18 +129,6 @@ test('target - element', async function(assert) {
     dialogText: 'Target - Element',
     closeSelector: dialogCloseButton,
     hasOverlay: false
-  });
-});
-
-test('subclassed modal', async function(assert) {
-  await assert.dialogOpensAndCloses({
-    openSelector: '#example-subclass button',
-    dialogText: 'Via Subclass',
-    closeSelector: overlaySelector,
-    hasOverlay: true,
-    whileOpen() {
-      assert.ok(Ember.$(dialogSelector).hasClass('my-cool-modal'), 'has provided containerClassNames');
-    }
   });
 });
 

--- a/tests/acceptance/tethered-test.js
+++ b/tests/acceptance/tethered-test.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+let application;
+const dialogSelector = '.ember-modal-dialog';
+const dialogCloseButton = [dialogSelector, 'button'].join(' ');
+
+module('Acceptance: modal-dialog | tethered', {
+  beforeEach() {
+    application = startApp();
+    visit('/tethered');
+  },
+
+  afterEach() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('target - selector', function(assert) {
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-target-selector button',
+    dialogText: 'Target - Selector',
+    closeSelector: dialogCloseButton,
+    hasOverlay: false,
+    whileOpen() {
+      assert.ok(Ember.$(dialogSelector).hasClass('ember-tether-target-attached-left'), 'has targetAttachment class name');
+    }
+  });
+});
+
+test('target - element', function(assert) {
+  assert.dialogOpensAndCloses({
+    openSelector: '#example-target-element button',
+    dialogText: 'Target - Element',
+    closeSelector: dialogCloseButton,
+    hasOverlay: false
+  });
+});

--- a/tests/dummy/app/controllers/tethered.js
+++ b/tests/dummy/app/controllers/tethered.js
@@ -1,0 +1,117 @@
+import Ember from 'ember';
+const { get, set } = Ember;
+
+export default Ember.Controller.extend({
+  isShowingBasic: false,
+  isShowingTranslucent: false,
+  isShowingTranslucentWithCallback: false,
+  isShowingWithoutOverlay: false,
+  isShowingWithoutOverlayClickOutsideToClose: false,
+  isShowingWithoutOverlayClickOutsideToCloseAnotherOne: false,
+  isShowingTargetSelector: false,
+  isShowingTargetElement: false,
+  isShowingSubclassed: false,
+  isShowingCenteredScrolling: false,
+  isShowingElementCenterModal: false,
+  exampleTargetAttachment: 'middle left',
+  exampleAttachment: 'middle right',
+  nextAttachment(val) {
+    switch (val) {
+      case 'middle right':
+        return 'bottom center';
+      case 'bottom center':
+        return 'middle left';
+      case 'middle left':
+        return 'top center';
+      case 'top center':
+        return 'middle right';
+    }
+    return false;
+  },
+  actions: {
+    toggleActiveComponent() {
+      if (get(this, 'activeComponent') === 'modal-dialog') {
+        set(this, 'activeComponent', 'tether-dialog');
+      } else {
+        set(this, 'activeComponent', 'modal-dialog');
+      }
+    },
+    toggleBasic() {
+      this.toggleProperty('isShowingBasic');
+    },
+    toggleTranslucent() {
+      this.toggleProperty('isShowingTranslucent');
+    },
+    toggleTranslucentWithCallback() {
+      this.toggleProperty('isShowingTranslucentWithCallback');
+    },
+    toggleWithoutOverlay() {
+      this.toggleProperty('isShowingWithoutOverlay');
+    },
+    toggleWithoutOverlayClickOutsideToClose() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToClose');
+    },
+    toggleWithoutOverlayClickOutsideToCloseAnotherOne() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToCloseAnotherOne');
+    },
+    toggleTargetSelector() {
+      if (this.get('isShowingTargetSelector')) {
+        let newTargetAttachment = this.nextAttachment(this.get('exampleTargetAttachment'));
+        let newAttachment = this.nextAttachment(this.get('exampleAttachment'));
+        this.set('exampleTargetAttachment', newTargetAttachment);
+        this.set('exampleAttachment', newAttachment);
+        if (newTargetAttachment !== 'middle left') {
+          return;
+        }
+      }
+      this.toggleProperty('isShowingTargetSelector');
+    },
+    toggleTargetElement() {
+      if (this.get('isShowingTargetElement')) {
+        let newTargetAttachment = this.nextAttachment(this.get('exampleTargetAttachment'));
+        let newAttachment = this.nextAttachment(this.get('exampleAttachment'));
+        this.set('exampleTargetAttachment', newTargetAttachment);
+        this.set('exampleAttachment', newAttachment);
+        if (newTargetAttachment !== 'middle left') {
+          return;
+        }
+      }
+      this.toggleProperty('isShowingTargetElement');
+    },
+    toggleSubclassed() {
+      this.toggleProperty('isShowingSubclassed');
+    },
+    toggleCenteredScrolling() {
+      this.toggleProperty('isShowingCenteredScrolling');
+
+      if (this.get('isShowingCenteredScrolling')) {
+        Ember.$('#modal-overlays').addClass('active');
+        Ember.$('body').addClass('centered-modal-showing');
+      } else {
+        Ember.$('#modal-overlays').removeClass('active');
+        Ember.$('body').removeClass('centered-modal-showing');
+      }
+    },
+    toggleElementCenterModal() {
+      this.toggleProperty('isShowingElementCenterModal');
+      if (this.get('isShowingElementCenterModal')) {
+        this.set('targetAttachment', 'elementCenter');
+        this.set('exampleTargetAttachment', 'elementCenter');
+        this.set('exampleAttachment', 'elementCenter');
+      }
+    },
+    closeTargetSelector() {
+      this.set('isShowingTargetSelector', false);
+      this.set('exampleTargetAttachment', 'middle left');
+      this.set('exampleAttachment', 'middle right');
+    },
+    closeTargetElement() {
+      this.set('isShowingTargetElement', false);
+      this.set('exampleTargetAttachment', 'middle left');
+      this.set('exampleAttachment', 'middle right');
+    },
+    clickedTranslucentOverlay() {
+      window.onClickOverlayCallbackCalled = true;
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('tethered');
   this.route('tether-dialog'); //deprecated
 });
 

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,10 +1,10 @@
 <div class="ApplicationRoute">
   <p class="ApplicationRoute-summary">
-    Ember Modal Dialog provides two different modal components.
+    The modal-dialog component can behave in two different ways.
   </p>
   <ul class="ApplicationRoute-nav">
-    <li>{{#link-to 'index'}}modal-dialog{{/link-to}}</li>
-    <li>{{#link-to 'tether-dialog'}}tether-dialog{{/link-to}}</li>
+    <li>{{#link-to 'index'}}css-positioned{{/link-to}}</li>
+    <li>{{#link-to 'tethered'}}tethered{{/link-to}}</li>
   </ul>
 
   {{outlet}}

--- a/tests/dummy/app/templates/tether-dialog.hbs
+++ b/tests/dummy/app/templates/tether-dialog.hbs
@@ -169,23 +169,6 @@
   {{/if}}
 </div>
 
-<div class='example' id='example-subclass'>
-  <h2>Via Subclass</h2>
-  <button {{action 'toggleSubclassed'}}>Do It</button>
-  {{code-snippet name='subclass.js'}}
-  {{code-snippet name='subclass-tether-dialog.hbs'}}
-  {{#if isShowingSubclassed}}
-    {{!-- BEGIN-SNIPPET subclass-tether-dialog --}}
-    {{#my-cool-modal-dialog close='toggleSubclassed'
-                    translucentOverlay=true}}
-      <h1>Stop! Modal Time!</h1>
-      <p>Via Subclass</p>
-      <button {{action 'toggleSubclassed'}}>Close</button>
-    {{/my-cool-modal-dialog}}
-    {{!-- END-SNIPPET --}}
-  {{/if}}
-</div>
-
 <div class='example' id='example-in-place'>
 <h2>In Place</h2>
   <button {{action 'toggleInPlace'}}>Do It</button>

--- a/tests/dummy/app/templates/tethered.hbs
+++ b/tests/dummy/app/templates/tethered.hbs
@@ -1,0 +1,112 @@
+<h1 id="title">Tethered examples of the <code>modal-dialog</code> component</h1>
+<p>
+  These examples specify a <code>tetherTarget</code> property, which makes the
+  component attempt to use <code>ember-tether</code> to be positioned relative
+  to the <code>tetherTarget</code> element and sit in a layer above the rest of the
+  document. It requires that you install
+  <a href="https://github.com/yapplabs/ember-tether"><code>ember-tether</code></a>
+  into your app.
+</p>
+<p>
+  If a <code>tetherTarget</code> is specified and <code>ember-tether</code> is
+  not installed, an error will be raised.
+</p>
+
+<div class='example' id='example-custom-styles'>
+  <h2>Custom Styles</h2>
+  <button onclick={{action (mut isShowingCustomStyles) true}}>Do It</button>
+  {{code-snippet name='custom-styles-modal-dialog-tethered.hbs'}}
+  {{code-snippet name='custom-styles.scss'}}
+  {{#if isShowingCustomStyles}}
+    {{!-- BEGIN-SNIPPET custom-styles-modal-dialog-tethered --}}
+    {{#modal-dialog
+        onClose=(action (mut isShowingCustomStyles) false)
+        tetherTarget='body'
+        targetModifier='visible'
+        targetAttachment='top right'
+        attachment='top right'
+        containerClass='custom-styles-modal-container'
+        overlayClass='custom-styles-overlay'
+        animatable=false
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Custom Styles</p>
+      <button onclick={{action (mut isShowingCustomStyles) false}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-target-selector'>
+  <h2>Target (Selector)</h2>
+  <div class='targetContainer'>
+    <button id='alignTetherDialogToMe' {{action 'toggleTargetSelector'}}>Do It</button>
+  </div>
+  {{code-snippet name='target-selector-modal-dialog-tethered.hbs'}}
+  {{#if isShowingTargetSelector}}
+    {{!-- BEGIN-SNIPPET target-selector-modal-dialog-tethered --}}
+    {{#modal-dialog
+      onClose='toggleTargetSelector'
+      hasOverlay=false
+      targetAttachment=exampleTargetAttachment
+      attachment=exampleAttachment
+      tetherTarget='#alignTetherDialogToMe'
+      animatable=false
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Target - Selector: '#alignTetherDialogToMe'</p>
+      <p>Target Attachment: {{exampleTargetAttachment}}</p>
+      <p>Attachment: {{exampleAttachment}}</p>
+      <button {{action 'closeTargetSelector'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-target-element'>
+  <h2>Target (Element)</h2>
+  <div class='targetContainer'>
+    <span id="bwtde">
+      <button {{action 'toggleTargetElement'}}>Do It</button>
+    </span>
+  </div>
+  {{code-snippet name='target-element-modal-dialog-tethered.hbs'}}
+  {{#if isShowingTargetElement}}
+    {{!-- BEGIN-SNIPPET target-element-modal-dialog-tethered --}}
+    {{#modal-dialog
+        onClose='toggleTargetElement'
+        hasOverlay=false
+        targetAttachment=exampleTargetAttachment
+        attachment=exampleAttachment
+        tetherTarget="#bwtde"
+        animatable=false
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Target - Element #bwtde</p>
+      <p>Target Attachment: {{exampleTargetAttachment}}</p>
+      <p>Attachment: {{exampleAttachment}}</p>
+      <button {{action 'closeTargetElement'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example'>
+  <h2>Element Center</h2>
+  <span id='elementCenter'>
+    <button {{action 'toggleElementCenterModal'}}>Element Center</button>
+  </span>
+  {{code-snippet name='element-centered-modal-dialog-tethered.hbs'}}
+  {{#if isShowingElementCenterModal}}
+  {{!-- BEGIN-SNIPPET element-centered-modal-dialog-tethered --}}
+    {{#modal-dialog
+        translucentOverlay=true
+        tetherTarget='#elementCenter'
+        onClose='toggleElementCenterModal'
+        animatable=false
+    }}
+      <p>Centered on element.</p>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>


### PR DESCRIPTION
- chooses which strategy to use based on whether a `tetherTarget` property is passed
- `tether-dialog` component usage is deprecated and will be removed in 3.0.0 - switch to using `modal-dialog` and pass a `tetherTarget` property
- passing a `target` to `modal-dialog` is deprecated and positioning for non-tether will be 100% CSS in 3.0.0
- renderInPlace=true now renders without a wrapper div