### PR TITLE
Allow specifying `hasOverlay=false` to suppress output of the overlay div.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The modal-dialog component supports the following properties:
 
 Property              | Purpose
 --------------------- | -------------
+`hasOverlay`          | Toggles presence of overlay div in DOM
 `translucentOverlay`  | Indicates translucence of overlay, toggles presence of `translucent` CSS selector
 `onClose`               | The action handler for the dialog's `onClose` action. This action triggers when the user clicks the modal overlay.
 `onClickOverlay`      | An action to be called when the overlay is clicked. If this action is specified, clicking the overlay will invoke it instead of `onClose`.

--- a/addon/templates/components/basic-dialog.hbs
+++ b/addon/templates/components/basic-dialog.hbs
@@ -1,6 +1,16 @@
-{{#ember-wormhole to=destinationElementId renderInPlace=renderInPlace}}
-  <div class={{wrapperClassNamesString}}>
-    <div class={{overlayClassNamesString}} onclick={{action (ignore-children onClickOverlay)}} tabindex="-1" data-emd-overlay>
+{{#ember-wormhole to=destinationElementId}}
+  <div class="{{wrapperClassNamesString}} {{wrapperClass}}">
+    {{#if hasOverlay}}
+      <div class={{overlayClassNamesString}} onclick={{action (ignore-children onClickOverlay)}} tabindex="-1" data-emd-overlay>
+        {{#ember-modal-dialog-positioned-container
+            class=containerClassNamesString
+            targetAttachment=targetAttachment
+            target=legacyTarget
+        }}
+          {{yield}}
+        {{/ember-modal-dialog-positioned-container}}
+      </div>
+    {{else}}
       {{#ember-modal-dialog-positioned-container
           class=containerClassNamesString
           targetAttachment=targetAttachment
@@ -8,6 +18,6 @@
       }}
         {{yield}}
       {{/ember-modal-dialog-positioned-container}}
-    </div>
+    {{/if}}
   </div>
 {{/ember-wormhole}}

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -53,6 +53,20 @@ test('modal with translucent overlay', async function(assert) {
   });
 });
 
+test('modal without overlay', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: '#example-without-overlay'
+  });
+
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-without-overlay button',
+    dialogText: 'Without Overlay',
+    closeSelector: dialogCloseButton
+  });
+});
+
 test('clicking translucent overlay triggers callback', async function(assert) {
   window.onClickOverlayCallbackCalled = false;
 

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -62,6 +62,25 @@
   {{/if}}
 </div>
 
+<div class='example' id='example-without-overlay'>
+  <h2>Without Overlay</h2>
+  <button onclick={{action (mut isShowingWithoutOverlay) true}}>Do It</button>
+  {{code-snippet name='modal-dialog-without-overlay.hbs'}}
+  {{#if isShowingWithoutOverlay}}
+    {{!-- BEGIN-SNIPPET modal-dialog-without-overlay --}}
+    {{#modal-dialog
+        onClose=(action (mut isShowingWithoutOverlay) false)
+        hasOverlay=false
+        clickOutsideToClose=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Without Overlay</p>
+      <button onclick={{action (mut isShowingWithoutOverlay) false}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
 <div class='example' id='example-custom-styles'>
   <h2>Custom Styles</h2>
   <button onclick={{action (mut isShowingCustomStyles) true}}>Do It</button>


### PR DESCRIPTION
- This already worked for the tethering code path.