### PR TITLE
Make modal-dialog component animatable via liquid-fire

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Property              | Purpose
 `overlayClassNames`   | CSS class names to append to overlay divs. This is a concatenated property, so it does **not** replace the default overlay class (default: `'ember-modal-overlay'`. If you subclass this component, you may define this in your subclass.)
 `wrapperClass`        | CSS class name(s) to append to wrapper divs. Set this from template.
 `wrapperClassNames`   | CSS class names to append to wrapper divs. This is a concatenated property, so it does **not** replace the default container class (default: `'ember-modal-wrapper'`. If you subclass this component, you may define this in your subclass.)
+`animatable`          | A boolean, when `true` makes modal animatable using `liquid-fire` (requires `liquid-wormhole` to be installed, and for tethering situations `liquid-tether`. Having these optional dependencies installed and NOT explicitly specifying `animatable` is deprecated in 2.x and is equivalent to `animatable=false` for backwards compatibility. As of 3.x, the implicit default will be `animatable=true` when the optional `liquid-wormhole`/`liquid-tether` dependency is present.
 
 The above properties of the `modal-dialog` component can be used without any additional  dependencies.
 
@@ -117,6 +118,21 @@ Property              | Purpose
 `offset`              | Delegates to Hubspot Tether*
 `targetOffset`        | Delegates to Hubspot Tether*
 `constraints`         | Delegates to Hubspot Tether*
+
+#### Animation
+
+This component supports animation when certain addons are present (liquid-wormhole, liquid-tether).
+
+_Current 2.x behavior:_  Having these optional dependencies installed and NOT explicitly specifying `animatable` is deprecated in 2.x and is equivalent to `animatable=false` for backwards compatibility. To get animation, pass `animatable=true` and install `liquid-wormhole` for non-tethering usage and `liquid-tether` for tethering usage.
+
+_Upcoming 3.x behavior:_ Detection will be automatic. To opt out of using animatable features when you have these `liquid-*` addons installed, pass `animatable=false`.
+
+### Optional dependencies
+
+`ember install ember-tether` [Docs](//github.com/yapplabs/ember-tether/)
+`ember install liquid-wormhole` [Docs](//pzuraq.github.io/liquid-wormhole/)
+`ember install liquid-tether` [Docs](//pzuraq.github.io/liquid-tether/)
+`ember install liquid-fire` [Docs](//ember-animation.github.io/liquid-fire/)
 
 
 ## Which Component Should I Use?

--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -27,10 +27,10 @@ export default Ember.Component.extend({
       this.get('overlayClass')
     ].filter((className) => !isEmpty(className)).join(' ');
   }),
-  wrapperClassNamesString: computed('wrapperClassNames.[]', 'isCentered', 'variantWrapperClass', 'wrapperClass', function(){
+  wrapperClassNamesString: computed('wrapperClassNames.[]', 'targetAttachmentClass', 'variantWrapperClass', 'wrapperClass', function(){
     return [
       this.get('wrapperClassNames').join(' '),
-      this.get('isCentered') ? 'emd-centered' : null,
+      this.get('targetAttachmentClass').replace('emd-', 'emd-wrapper-'),
       this.get('variantWrapperClass'),
       this.get('wrapperClass')
     ].filter((className) => !isEmpty(className)).join(' ');

--- a/addon/components/deprecated-tether-dialog.js
+++ b/addon/components/deprecated-tether-dialog.js
@@ -4,7 +4,7 @@ import layout from '../templates/components/deprecated-tether-dialog';
 import { deprecate } from '@ember/debug';
 
 const { dasherize } = Ember.String;
-const { computed, get, inject } = Ember;
+const { computed, get, inject, isEmpty } = Ember;
 const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
 
 export default BasicDialog.extend({
@@ -50,6 +50,15 @@ export default BasicDialog.extend({
     },
   }),
   containerClassNames: ['ember-modal-dialog'], // set this in a subclass definition
+  containerClassNamesString: computed('containerClassNames.[]', 'targetAttachmentClass', 'attachmentClass', 'containerClass', 'renderInPlace', function() {
+    return [
+      this.get('containerClassNames').join(' '),
+      this.get('targetAttachmentClass'),
+      this.get('attachmentClass'),
+      this.get('containerClass'),
+      this.get('renderInPlace') ? 'ember-modal-dialog-in-place emd-in-place' : null
+    ].filter((className) => !isEmpty(className)).join(' ');
+  }),
 
   // overlayClass - set this from templates
   "overlay-class": computed('overlayClass', {

--- a/addon/components/in-place-dialog.js
+++ b/addon/components/in-place-dialog.js
@@ -13,7 +13,7 @@ export default Ember.Component.extend({
   layout,
 
   containerClass: null, // passed in
-  containerClassNames: ['ember-modal-dialog', 'emd-in-place'], // set this in a subclass definition
+  containerClassNames: ['ember-modal-dialog', 'ember-modal-dialog-in-place', 'emd-in-place'], // set this in a subclass definition
   containerClassNamesString: computedJoin('containerClassNames'),
 
   concatenatedProperties: ['containerClassNames']

--- a/addon/components/liquid-dialog.js
+++ b/addon/components/liquid-dialog.js
@@ -1,0 +1,9 @@
+import BasicDialog from './basic-dialog';
+import layout from '../templates/components/liquid-dialog';
+
+export default BasicDialog.extend({
+  layout,
+  hasOverlay: true,
+  containerClassNames: ['liquid-dialog'],
+  variantWrapperClass: 'emd-animatable'
+});

--- a/addon/components/liquid-tether-dialog.js
+++ b/addon/components/liquid-tether-dialog.js
@@ -1,0 +1,42 @@
+import Ember from 'ember';
+import BasicDialog from './basic-dialog';
+import layout from '../templates/components/liquid-tether-dialog';
+
+const { dasherize } = Ember.String;
+const { computed } = Ember;
+
+export default BasicDialog.extend({
+  layout,
+
+  targetAttachmentClass: computed('targetAttachment', function() {
+    let targetAttachment = this.get('targetAttachment') || '';
+    return `ember-modal-dialog-target-attachment-${dasherize(targetAttachment)}`;
+  }),
+
+  targetAttachment: null,
+  attachment: null,
+  didReceiveAttrs() {
+    this._super(...arguments);
+    if (!this.get('attachment')) {
+      this.set('attachment', 'middle center');
+    }
+    if (!this.get('targetAttachment')) {
+      this.set('targetAttachment', 'middle center');
+    }
+  },
+  tetherClassPrefix: computed({
+    get() {
+      return 'liquid-tether';
+    }, set(key, val) {
+      if (val) {
+        return val;
+      }
+      return 'liquid-tether';
+    }
+  }),
+  hasOverlay: true,
+  tetherTarget: null, // element, css selector, view instance, 'viewport', or 'scroll-handle'
+  // offset - passed in
+  // targetOffset - passed in
+  // targetModifier - passed in
+});

--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -18,11 +18,17 @@ export default Ember.Component.extend({
     if (this.get('renderInPlace')) {
       return false;
     }
-    if (this.get('target') && this.get('targetAttachment')) {
+    let target = this.get('target');
+    let targetAttachment = this.get('targetAttachment');
+    if (target === 'body' && (targetAttachment === 'center' || targetAttachment === 'middle center')) {
+      return false;
+    }
+
+    if (target && targetAttachment) {
       return true;
     }
-    const targetAttachment = this.get('targetAttachment');
-    return targetAttachment === 'center' || targetAttachment === 'middle center';
+
+    return false;
   }),
 
   didGetPositioned: observer('isPositioned', on('didInsertElement', function() {

--- a/addon/templates/components/liquid-dialog.hbs
+++ b/addon/templates/components/liquid-dialog.hbs
@@ -1,0 +1,26 @@
+{{#if isOverlaySibling}}
+  {{#liquid-wormhole stack='overlay' class=(concat 'liquid-dialog-container ' wrapperClassNamesString ' ' wrapperClass)}}
+    <div class="{{wrapperClassNamesString}} {{wrapperClass}}">
+      {{#if hasOverlay}}
+        <div class={{overlayClassNamesString}} onclick={{action onClickOverlay}} tabindex="-1" data-emd-overlay></div>
+      {{/if}}
+      <div class={{containerClassNamesString}}>
+        {{yield}}
+      </div>
+    </div>
+  {{/liquid-wormhole}}
+{{else}}
+  {{#liquid-wormhole stack='overlay' class=(concat 'liquid-dialog-container ' wrapperClassNamesString ' ' wrapperClass)}}
+    {{#if hasOverlay}}
+      <div class={{overlayClassNamesString}} onclick={{action (ignore-children onClickOverlay)}} tabindex="-1" data-emd-overlay>
+        <div class={{containerClassNamesString}}>
+          {{yield}}
+        </div>
+      </div>
+    {{else}}
+      <div class={{containerClassNamesString}}>
+        {{yield}}
+      </div>
+    {{/if}}
+  {{/liquid-wormhole}}
+{{/if}}

--- a/addon/templates/components/liquid-tether-dialog.hbs
+++ b/addon/templates/components/liquid-tether-dialog.hbs
@@ -1,0 +1,19 @@
+{{#if hasOverlay}}
+  {{#liquid-wormhole stack='modal-overlay' class="liquid-dialog-container"}}
+    <div class={{overlayClassNamesString}} onclick={{action onClickOverlay}} tabindex="-1" data-emd-overlay></div>
+  {{/liquid-wormhole}}
+{{/if}}
+{{#liquid-tether
+    class=containerClassNamesString
+    stack='modal-dialog'
+    target=tetherTarget
+    attachment=attachment
+    targetAttachment=targetAttachment
+    targetModifier=targetModifier
+    classPrefix=tetherClassPrefix
+    offset=offset
+    targetOffset=targetOffset
+    constraints=constraints
+}}
+  {{yield}}
+{{/liquid-tether}}

--- a/app/components/ember-modal-dialog/-liquid-dialog.js
+++ b/app/components/ember-modal-dialog/-liquid-dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-modal-dialog/components/liquid-dialog';

--- a/app/components/ember-modal-dialog/-liquid-tether-dialog.js
+++ b/app/components/ember-modal-dialog/-liquid-tether-dialog.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-modal-dialog/components/liquid-tether-dialog';

--- a/app/services/modal-dialog.js
+++ b/app/services/modal-dialog.js
@@ -11,6 +11,8 @@ function computedFromConfig(prop) {
 
 export default Service.extend({
   hasEmberTether: computedFromConfig('hasEmberTether'),
+  hasLiquidWormhole: computedFromConfig('hasLiquidWormhole'),
+  hasLiquidTether: computedFromConfig('hasLiquidTether'),
   destinationElementId: computed(function() {
     /*
       everywhere except test, this property will be overwritten

--- a/app/styles/ember-modal-dialog/ember-modal-structure.scss
+++ b/app/styles/ember-modal-dialog/ember-modal-structure.scss
@@ -1,16 +1,46 @@
-.ember-modal-overlay {
-  height: 100vh;
-  left: 0;
-  position: fixed;
-  right: 0;
-  top: 0;
-  z-index: 50;
-}
 .ember-modal-dialog {
-  z-index: 50;
+  z-index: 51;
   position: fixed;
 
-  &.ember-modal-dialog-in-place {
+  &.emd-in-place {
     position: static;
   }
+}
+.ember-modal-wrapper.emd-static.emd-wrapper-target-attachment-center {
+  .ember-modal-dialog {
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+
+.ember-modal-wrapper.emd-animatable {
+  &.emd-wrapper-target-attachment-center {
+    width: 100vw;
+    height: 100vh;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 50;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  &.emd-wrapper-target-attachment-center .ember-modal-overlay {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .ember-modal-dialog {
+    position: relative;
+  }
+}
+
+.ember-modal-overlay {
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: 50;
 }

--- a/config/environment.js
+++ b/config/environment.js
@@ -7,8 +7,12 @@ module.exports = function( environment, appConfig, addon ) {
   appConfig['ember-modal-dialog'] = appConfig['ember-modal-dialog'] || {};
 
   var checker = new VersionChecker(addon);
+  var hasLiquidWormhole = checker.for('liquid-wormhole', 'npm').version;
+  var hasLiquidTether = checker.for('liquid-tether', 'npm').version;
   var hasEmberTether = checker.for('ember-tether', 'npm').version;
 
+  appConfig['ember-modal-dialog']['hasLiquidWormhole'] = hasLiquidWormhole;
+  appConfig['ember-modal-dialog']['hasLiquidTether'] = hasLiquidTether;
   appConfig['ember-modal-dialog']['hasEmberTether'] = hasEmberTether;
 
   return appConfig;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,9 @@
     "ember-source": "~2.13.0",
     "ember-tether": "^1.0.0-beta.0",
     "ember-truth-helpers": "^1.3.0",
+    "liquid-fire": "^0.27.3",
+    "liquid-tether": "^2.0.4",
+    "liquid-wormhole": "^2.0.5",
     "loader.js": "^4.4.0"
   },
   "engines": {

--- a/tests/acceptance/animatable-test.js
+++ b/tests/acceptance/animatable-test.js
@@ -1,0 +1,81 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+let application;
+const modalRootElementSelector = '#modal-overlays';
+const overlaySelector = '[data-emd-overlay]';
+const wrapperSelector = '.ember-modal-wrapper';
+const dialogSelector = '.ember-modal-dialog';
+const dialogCloseButton = [dialogSelector, 'button'].join(' ');
+
+module('Acceptance: modal-dialog | animatable', {
+  async beforeEach() {
+    application = startApp();
+    await visit('/animatable');
+  },
+
+  afterEach() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('basic modal', async function(assert) {
+  assert.isPresentOnce(modalRootElementSelector);
+  assert.isAbsent(overlaySelector);
+  assert.isPresentOnce('#example-basic button');
+
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-basic button',
+    dialogText: 'Basic',
+    closeSelector: wrapperSelector
+  });
+
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-basic button',
+    dialogText: 'Basic',
+    closeSelector: dialogCloseButton
+  });
+});
+
+test('modal with translucent overlay', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-translucent button',
+    dialogText: 'With Translucent Overlay',
+    closeSelector: wrapperSelector
+  });
+
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-translucent button',
+    dialogText: 'With Translucent Overlay',
+    closeSelector: dialogCloseButton
+  });
+});
+
+test('modal with custom styles', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-custom-styles button',
+    dialogText: 'Custom Styles',
+    closeSelector: overlaySelector,
+    whileOpen() {
+      assert.ok(Ember.$(overlaySelector).hasClass('custom-styles-overlay'), 'has provided overlayClass');
+      assert.ok(Ember.$(dialogSelector).hasClass('custom-styles-modal-container'), 'has provided containerClass');
+    }
+  });
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-custom-styles button',
+    dialogText: 'Custom Styles',
+    closeSelector: dialogCloseButton
+  });
+});
+
+test('subclassed modal', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-subclass button',
+    dialogText: 'Via Subclass',
+    closeSelector: overlaySelector,
+    whileOpen() {
+      assert.ok(Ember.$(dialogSelector).hasClass('my-cool-modal'), 'has provided containerClassNames');
+    }
+  });
+});

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -10,7 +10,7 @@ const overlaySelector = '.ember-modal-overlay';
 const dialogSelector = '.ember-modal-dialog';
 const dialogCloseButton = [dialogSelector, 'button'].join(' ');
 
-module('Acceptance: modal-dialog | not tethered', {
+module('Acceptance: modal-dialog | no animation, no tether', {
   async beforeEach() {
     application = startApp();
     await visit('/');
@@ -115,7 +115,7 @@ test('modal with custom styles', async function(assert) {
     dialogText: 'Custom Styles',
     closeSelector: overlaySelector,
     whileOpen() {
-      assert.ok(Ember.$(`${modalRootElementSelector} ${overlaySelector}`).hasClass('custom-styles-modal'), 'has provided overlayClass');
+      assert.ok(Ember.$(`${modalRootElementSelector} ${overlaySelector}`).hasClass('custom-styles-overlay'), 'has provided overlayClass');
       assert.ok(Ember.$(`${modalRootElementSelector} ${dialogSelector}`).hasClass('custom-styles-modal-container'), 'has provided container-class');
     }
   });

--- a/tests/acceptance/tethered-animatable-test.js
+++ b/tests/acceptance/tethered-animatable-test.js
@@ -1,0 +1,39 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+
+let application;
+const dialogSelector = '.ember-modal-dialog';
+const dialogCloseButton = [dialogSelector, 'button'].join(' ');
+
+module('Acceptance: modal-dialog | tethered and animatable', {
+  async beforeEach() {
+    application = startApp();
+    await visit('/tethered-animatable');
+  },
+
+  afterEach() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('target - selector', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-target-selector button',
+    dialogText: 'Target - Selector',
+    closeSelector: dialogCloseButton,
+    hasOverlay: false,
+    whileOpen() {
+      assert.ok(Ember.$(dialogSelector).hasClass('liquid-tether-target-attached-left'), 'has targetAttachment class name');
+    }
+  });
+});
+
+test('target - element', async function(assert) {
+  await assert.dialogOpensAndCloses({
+    openSelector: '#example-target-element button',
+    dialogText: 'Target - Element',
+    closeSelector: dialogCloseButton,
+    hasOverlay: false
+  });
+});

--- a/tests/dummy/app/controllers/animatable.js
+++ b/tests/dummy/app/controllers/animatable.js
@@ -1,0 +1,71 @@
+import Ember from 'ember';
+const { get, set } = Ember;
+
+export default Ember.Controller.extend({
+  isShowingBasic: false,
+  isShowingTranslucent: false,
+  isShowingTranslucentWithCallback: false,
+  isShowingWithoutOverlay: false,
+  isShowingWithoutOverlayClickOutsideToClose: false,
+  isShowingWithoutOverlayClickOutsideToCloseAnotherOne: false,
+  isShowingSubclassed: false,
+  isShowingCenteredScrolling: false,
+  isShowingElementCenterModal: false,
+  nextAttachment(val) {
+    switch (val) {
+      case 'middle right':
+        return 'bottom center';
+      case 'bottom center':
+        return 'middle left';
+      case 'middle left':
+        return 'top center';
+      case 'top center':
+        return 'middle right';
+    }
+    return false;
+  },
+  actions: {
+    toggleActiveComponent() {
+      if (get(this, 'activeComponent') === 'modal-dialog') {
+        set(this, 'activeComponent', 'tether-dialog');
+      } else {
+        set(this, 'activeComponent', 'modal-dialog');
+      }
+    },
+    toggleBasic() {
+      this.toggleProperty('isShowingBasic');
+    },
+    toggleTranslucent() {
+      this.toggleProperty('isShowingTranslucent');
+    },
+    toggleTranslucentWithCallback() {
+      this.toggleProperty('isShowingTranslucentWithCallback');
+    },
+    toggleWithoutOverlay() {
+      this.toggleProperty('isShowingWithoutOverlay');
+    },
+    toggleWithoutOverlayClickOutsideToClose() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToClose');
+    },
+    toggleWithoutOverlayClickOutsideToCloseAnotherOne() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToCloseAnotherOne');
+    },
+    toggleSubclassed() {
+      this.toggleProperty('isShowingSubclassed');
+    },
+    toggleCenteredScrolling() {
+      this.toggleProperty('isShowingCenteredScrolling');
+
+      if (this.get('isShowingCenteredScrolling')) {
+        Ember.$('#modal-overlays').addClass('active');
+        Ember.$('body').addClass('centered-modal-showing');
+      } else {
+        Ember.$('#modal-overlays').removeClass('active');
+        Ember.$('body').removeClass('centered-modal-showing');
+      }
+    },
+    clickedTranslucentOverlay() {
+      window.onClickOverlayCallbackCalled = true;
+    }
+  }
+});

--- a/tests/dummy/app/controllers/tethered-animatable.js
+++ b/tests/dummy/app/controllers/tethered-animatable.js
@@ -1,0 +1,117 @@
+import Ember from 'ember';
+const { get, set } = Ember;
+
+export default Ember.Controller.extend({
+  isShowingBasic: false,
+  isShowingTranslucent: false,
+  isShowingTranslucentWithCallback: false,
+  isShowingWithoutOverlay: false,
+  isShowingWithoutOverlayClickOutsideToClose: false,
+  isShowingWithoutOverlayClickOutsideToCloseAnotherOne: false,
+  isShowingTargetSelector: false,
+  isShowingTargetElement: false,
+  isShowingSubclassed: false,
+  isShowingCenteredScrolling: false,
+  isShowingElementCenterModal: false,
+  exampleTargetAttachment: 'middle left',
+  exampleAttachment: 'middle right',
+  nextAttachment(val) {
+    switch (val) {
+      case 'middle right':
+        return 'bottom center';
+      case 'bottom center':
+        return 'middle left';
+      case 'middle left':
+        return 'top center';
+      case 'top center':
+        return 'middle right';
+    }
+    return false;
+  },
+  actions: {
+    toggleActiveComponent() {
+      if (get(this, 'activeComponent') === 'modal-dialog') {
+        set(this, 'activeComponent', 'tether-dialog');
+      } else {
+        set(this, 'activeComponent', 'modal-dialog');
+      }
+    },
+    toggleBasic() {
+      this.toggleProperty('isShowingBasic');
+    },
+    toggleTranslucent() {
+      this.toggleProperty('isShowingTranslucent');
+    },
+    toggleTranslucentWithCallback() {
+      this.toggleProperty('isShowingTranslucentWithCallback');
+    },
+    toggleWithoutOverlay() {
+      this.toggleProperty('isShowingWithoutOverlay');
+    },
+    toggleWithoutOverlayClickOutsideToClose() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToClose');
+    },
+    toggleWithoutOverlayClickOutsideToCloseAnotherOne() {
+      this.toggleProperty('isShowingWithoutOverlayClickOutsideToCloseAnotherOne');
+    },
+    toggleTargetSelector() {
+      if (this.get('isShowingTargetSelector')) {
+        let newTargetAttachment = this.nextAttachment(this.get('exampleTargetAttachment'));
+        let newAttachment = this.nextAttachment(this.get('exampleAttachment'));
+        this.set('exampleTargetAttachment', newTargetAttachment);
+        this.set('exampleAttachment', newAttachment);
+        if (newTargetAttachment !== 'middle left') {
+          return;
+        }
+      }
+      this.toggleProperty('isShowingTargetSelector');
+    },
+    toggleTargetElement() {
+      if (this.get('isShowingTargetElement')) {
+        let newTargetAttachment = this.nextAttachment(this.get('exampleTargetAttachment'));
+        let newAttachment = this.nextAttachment(this.get('exampleAttachment'));
+        this.set('exampleTargetAttachment', newTargetAttachment);
+        this.set('exampleAttachment', newAttachment);
+        if (newTargetAttachment !== 'middle left') {
+          return;
+        }
+      }
+      this.toggleProperty('isShowingTargetElement');
+    },
+    toggleSubclassed() {
+      this.toggleProperty('isShowingSubclassed');
+    },
+    toggleCenteredScrolling() {
+      this.toggleProperty('isShowingCenteredScrolling');
+
+      if (this.get('isShowingCenteredScrolling')) {
+        Ember.$('#modal-overlays').addClass('active');
+        Ember.$('body').addClass('centered-modal-showing');
+      } else {
+        Ember.$('#modal-overlays').removeClass('active');
+        Ember.$('body').removeClass('centered-modal-showing');
+      }
+    },
+    toggleElementCenterModal() {
+      this.toggleProperty('isShowingElementCenterModal');
+      if (this.get('isShowingElementCenterModal')) {
+        this.set('targetAttachment', 'elementCenter');
+        this.set('exampleTargetAttachment', 'elementCenter');
+        this.set('exampleAttachment', 'elementCenter');
+      }
+    },
+    closeTargetSelector() {
+      this.set('isShowingTargetSelector', false);
+      this.set('exampleTargetAttachment', 'middle left');
+      this.set('exampleAttachment', 'middle right');
+    },
+    closeTargetElement() {
+      this.set('isShowingTargetElement', false);
+      this.set('exampleTargetAttachment', 'middle left');
+      this.set('exampleAttachment', 'middle right');
+    },
+    clickedTranslucentOverlay() {
+      window.onClickOverlayCallbackCalled = true;
+    }
+  }
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -8,6 +8,8 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('tethered');
+  this.route('animatable');
+  this.route('tethered-animatable');
   this.route('tether-dialog'); //deprecated
 });
 

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -70,24 +70,37 @@ h2 {
   padding: 0 0 8px 0;
   margin: 0;
 }
+// BEGIN-SNIPPET subclass-styles
 .my-cool-modal {
   border-radius: 100px;
   padding: 40px;
 }
+// END-SNIPPET
 
 // BEGIN-SNIPPET custom-styles
 $theme-color: #0f9d58;
 
-.custom-styles-modal {
+.custom-styles-overlay {
   background-color: rgba($theme-color, .77);
+}
+
+.custom-styles-overlay,
+.custom-styles-wrapper {
+  display: flex;
+  justify-content: flex-end;
+  align-items: flex-start;
+  width: 100vw;
+  height: 100vh;
+  position: fixed;
+  top: 0;
+  left: 0;
 }
 
 .custom-styles-modal-container {
   background: #222;
   color: white;
-  position: fixed;
-  right: 10px;
-  top: 10px;
+  margin-left: -25px;
+  margin-top: 10px;
   width: 300px;
 
   h1 {
@@ -103,7 +116,7 @@ $theme-color: #0f9d58;
   position: initial;
 }
 
-.ember-modal-dialog-in-place {
+.emd-in-place {
   position: initial;
 }
 // END-SNIPPET
@@ -113,31 +126,22 @@ body.centered-modal-showing {
   overflow: hidden;
 }
 .centered-scrolling-wrapper {
-  position: fixed;
-  z-index: 99;
+  width: 100vw;
   height: 100vh;
-  left: 0;
-  right: 0;
+  position: fixed;
   top: 0;
+  left: 0;
   overflow-y: scroll;
 }
 
 .centered-scrolling-overlay {
-  display: flex;
-  display: -webkit-flex;
-  align-items: flex-start;
-  -webkit-align-items: flex-start;
-  justify-content: center;
-  -webkit-justify-content: center;
-  min-height: 100vh;
-  padding: 1em;
   position: relative;
   height: auto;
-}
-
-.centered-scrolling-overlay.translucent {
-  background-color: rgba(0,0,0,0.5);
-  opacity: 1;
+  min-height: 100vh;
+  padding: 1em;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
 }
 
 /* basic modal style (an example, this is not necessary for the centering) */

--- a/tests/dummy/app/templates/animatable.hbs
+++ b/tests/dummy/app/templates/animatable.hbs
@@ -1,0 +1,153 @@
+<h1 id="title">Animatable examples of the <code>modal-dialog</code> component</h1>
+
+<p>
+  If <a href="http://pzuraq.github.io/liquid-wormhole/"><code>liquid-wormhole</code></a>
+  is installed and `animatable=true` is passed, the component will
+  automatically become animatable using <code>liquid-fire</code>.
+</p>
+
+<div class='example'>
+  <h3>app/transitions.js for these examples</h3>
+  {{code-snippet name='animated-transitions.js'}}
+</div>
+
+<div class='example' id='example-basic'>
+<h2>Basic</h2>
+  <button {{action 'toggleBasic'}}>Do It</button>
+  {{code-snippet name='basic-modal-dialog-animatable.hbs'}}
+  {{#if isShowingBasic}}
+    {{!-- BEGIN-SNIPPET basic-modal-dialog-animatable --}}
+    {{#modal-dialog
+        onClose='toggleBasic'
+        overlayPosition='sibling'
+        clickOutsideToClose=true
+        animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Basic</p>
+      <button {{action 'toggleBasic'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-translucent'>
+  <h2>With Translucent Overlay</h2>
+  <button {{action 'toggleTranslucent'}}>Do It</button>
+  {{code-snippet name='translucent-modal-dialog-animatable.hbs'}}
+  {{#if isShowingTranslucent}}
+    {{!-- BEGIN-SNIPPET translucent-modal-dialog-animatable --}}
+    {{#modal-dialog
+        onClose='toggleTranslucent'
+        translucentOverlay=true
+        overlayPosition='sibling'
+        clickOutsideToClose=true
+        animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>With Translucent Overlay</p>
+      <button {{action 'toggleTranslucent'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-without-overlay'>
+  <h2>Without Overlay</h2>
+  <button {{action 'toggleWithoutOverlay'}}>Do It</button>
+  {{code-snippet name='without-overlay-modal-dialog-animatable.hbs'}}
+  {{#if isShowingWithoutOverlay}}
+    {{!-- BEGIN-SNIPPET without-overlay-modal-dialog-animatable --}}
+    {{#modal-dialog
+        onClose='toggleWithoutOverlay'
+        hasOverlay=false
+        animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Without Overlay</p>
+      <button {{action 'toggleWithoutOverlay'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-without-overlay-click-outside-to-close'>
+  <h2>Without Overlay - Click Outside to Close</h2>
+  <button {{action 'toggleWithoutOverlayClickOutsideToClose'}}>Do It</button>
+  <button id="without-overlay-another-one-button"
+    {{action 'toggleWithoutOverlayClickOutsideToCloseAnotherOne'}}>Another one</button>
+  {{code-snippet name='without-overlay-click-outside-to-close-modal-dialog-animatable.hbs'}}
+  {{#if isShowingWithoutOverlayClickOutsideToClose}}
+    {{!-- BEGIN-SNIPPET without-overlay-click-outside-to-close-modal-dialog-animatable --}}
+    {{#modal-dialog
+          onClose='toggleWithoutOverlayClickOutsideToClose'
+          hasOverlay=false
+          clickOutsideToClose=true
+          animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Without Overlay - Click Outside to Close</p>
+      <button {{action 'toggleWithoutOverlayClickOutsideToClose'}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+  {{#if isShowingWithoutOverlayClickOutsideToCloseAnotherOne}}
+    {{#modal-dialog
+        onClose='toggleWithoutOverlayClickOutsideToCloseAnotherOne'
+        hasOverlay=false
+        clickOutsideToClose=true
+        offset='100px 0'
+        animatable=true
+    }}
+      <h1>Stop! Another modal!</h1>
+      <p>Without Overlay Another One - Click Outside to Close</p>
+      <button {{action 'toggleWithoutOverlayClickOutsideToCloseAnotherOne'}}>Close</button>
+    {{/modal-dialog}}
+  {{/if}}
+
+</div>
+
+<div class='example' id='example-custom-styles'>
+  <h2>Custom Styles</h2>
+  <button onclick={{action (mut isShowingCustomStyles true)}}>Do It</button>
+  {{code-snippet name='custom-styles-modal-dialog-animatable.hbs'}}
+  {{code-snippet name='custom-styles.scss'}}
+  {{#if isShowingCustomStyles}}
+    {{!-- BEGIN-SNIPPET custom-styles-modal-dialog-animatable --}}
+    {{#modal-dialog
+        onClose=(action (mut isShowingCustomStyles false))
+        containerClass='custom-styles-modal-container'
+        overlayClass='custom-styles-overlay'
+        wrapperClass='custom-styles-wrapper'
+        overlayPosition='sibling'
+        clickOutsideToClose=true
+        targetAttachment='none'
+        animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Custom Styles</p>
+      <button {{action (action (mut isShowingCustomStyles false))}}>Close</button>
+    {{/modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>
+
+<div class='example' id='example-subclass'>
+  <h2>Via Subclass</h2>
+  <button {{action 'toggleSubclassed'}}>Do It</button>
+  {{code-snippet name='subclass.js'}}
+  {{code-snippet name='subclass-modal-dialog-animatable.hbs'}}
+  {{code-snippet name='subclass-styles.scss'}}
+  {{#if isShowingSubclassed}}
+    {{!-- BEGIN-SNIPPET subclass-modal-dialog-animatable --}}
+    {{#my-cool-modal-dialog
+         onClose='toggleSubclassed'
+         animatable=true
+    }}
+      <h1>Stop! Modal Time!</h1>
+      <p>Via Subclass</p>
+      <button {{action 'toggleSubclassed'}}>Close</button>
+    {{/my-cool-modal-dialog}}
+    {{!-- END-SNIPPET --}}
+  {{/if}}
+</div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,10 +1,12 @@
 <div class="ApplicationRoute">
   <p class="ApplicationRoute-summary">
-    The modal-dialog component can behave in two different ways.
+    The modal-dialog component can behave in four different ways.
   </p>
   <ul class="ApplicationRoute-nav">
-    <li>{{#link-to 'index'}}css-positioned{{/link-to}}</li>
-    <li>{{#link-to 'tethered'}}tethered{{/link-to}}</li>
+    <li>{{#link-to 'index'}}css-positioned, not animatable{{/link-to}}</li>
+    <li>{{#link-to 'animatable'}}css-positioned, animatable{{/link-to}}</li>
+    <li>{{#link-to 'tethered'}}tethered, not animatable{{/link-to}}</li>
+    <li>{{#link-to 'tethered-animatable'}}tethered, animatable{{/link-to}}</li>
   </ul>
 
   {{outlet}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -5,7 +5,9 @@
 </p>
 <p>
   It requires no additional dependencies because <code>ember-wormhole</code> is included with
-  this addon.
+  this addon. If <code>liquid-wormhole</code> is installed, this component will detect it,
+  and will become {{#link-to 'animatable'}}animatable{{/link-to}} if
+  <code>animatable=true</code> is passed.
 </p>
 
 <div class='example' id='example-basic'>
@@ -111,7 +113,7 @@
       onClose=(action (mut isShowingCustomStyles) false)
         targetAttachment='none'
         containerClass=customContainerClassNames
-        overlayClass='custom-styles-modal'
+        overlayClass='custom-styles-overlay'
     }}
       <h1>Stop! Modal Time!</h1>
       <p>Custom Styles</p>
@@ -172,6 +174,7 @@
   <button onclick={{action (mut isShowingSubclassed) true}}>Do It</button>
   {{code-snippet name='subclass.js'}}
   {{code-snippet name='subclass-modal-dialog.hbs'}}
+  {{code-snippet name='subclass-styles.scss'}}
   {{#if isShowingSubclassed}}
     {{!-- BEGIN-SNIPPET subclass-modal-dialog --}}
     {{#my-cool-modal-dialog

--- a/tests/dummy/app/templates/tethered-animatable.hbs
+++ b/tests/dummy/app/templates/tethered-animatable.hbs
@@ -1,37 +1,37 @@
-<h1 id="title">Tethered examples of the <code>modal-dialog</code> component</h1>
+<h1 id="title">Tethered &amp; animated examples of the <code>modal-dialog</code> component</h1>
 <p>
-  These examples specify a <code>tetherTarget</code> property, which makes the
-  component attempt to use <code>ember-tether</code> to be positioned relative
-  to the <code>tetherTarget</code> element and sit in a layer above the rest of the
-  document. It requires that you install
-  <a href="https://github.com/yapplabs/ember-tether"><code>ember-tether</code></a>
-  into your app.
-</p>
-<p>
-  If <a href="http://pzuraq.github.io/liquid-tether/"><code>liquid-tether</code></a>
-  is installed and `animated=true` is passed, this component will become
-  {{#link-to 'tethered-animatable'}}animatable{{/link-to}}.
+  These examples specify a <code>tetherTarget</code> property, as well as demonstrate
+  animation via <code>liquid-fire</code>. If requires that you install
+  <a href="http://pzuraq.github.io/liquid-tether/"><code>liquid-tether</code></a>
+  into your app. Once installed and `animatable=true` is passed, the component will
+  automatically become animatable using <code>liquid-fire</code>.
 </p>
 <p>
   If a <code>tetherTarget</code> is specified and neither <code>ember-tether</code>
   nor <code>liquid-tether</code> is installed, an error will be raised.
 </p>
 
+<div class='example'>
+  <h3>app/transitions.js for these examples</h3>
+  {{code-snippet name='animated-with-tether-transitions.js'}}
+</div>
+
 <div class='example' id='example-custom-styles'>
   <h2>Custom Styles</h2>
   <button onclick={{action (mut isShowingCustomStyles) true}}>Do It</button>
-  {{code-snippet name='custom-styles-modal-dialog-tethered.hbs'}}
+  {{code-snippet name='custom-styles-modal-dialog-liquid-tether.hbs'}}
   {{code-snippet name='custom-styles.scss'}}
   {{#if isShowingCustomStyles}}
-    {{!-- BEGIN-SNIPPET custom-styles-modal-dialog-tethered --}}
+    {{!-- BEGIN-SNIPPET custom-styles-modal-dialog-liquid-tether --}}
     {{#modal-dialog
         onClose=(action (mut isShowingCustomStyles) false)
         tetherTarget='body'
-        targetModifier='visible'
         targetAttachment='top right'
+        targetModifier='visible'
         attachment='top right'
         containerClass='custom-styles-modal-container'
         overlayClass='custom-styles-overlay'
+        animatable=true
     }}
       <h1>Stop! Modal Time!</h1>
       <p>Custom Styles</p>
@@ -46,15 +46,16 @@
   <div class='targetContainer'>
     <button id='alignTetherDialogToMe' {{action 'toggleTargetSelector'}}>Do It</button>
   </div>
-  {{code-snippet name='target-selector-modal-dialog-tethered.hbs'}}
+  {{code-snippet name='target-selector-modal-dialog-liquid-tether.hbs'}}
   {{#if isShowingTargetSelector}}
-    {{!-- BEGIN-SNIPPET target-selector-modal-dialog-tethered --}}
+    {{!-- BEGIN-SNIPPET target-selector-modal-dialog-liquid-tether --}}
     {{#modal-dialog
       onClose='toggleTargetSelector'
       hasOverlay=false
       targetAttachment=exampleTargetAttachment
       attachment=exampleAttachment
       tetherTarget='#alignTetherDialogToMe'
+      animatable=true
     }}
       <h1>Stop! Modal Time!</h1>
       <p>Target - Selector: '#alignTetherDialogToMe'</p>
@@ -73,15 +74,16 @@
       <button {{action 'toggleTargetElement'}}>Do It</button>
     </span>
   </div>
-  {{code-snippet name='target-element-modal-dialog-tethered.hbs'}}
+  {{code-snippet name='target-element-modal-dialog-liquid-tether.hbs'}}
   {{#if isShowingTargetElement}}
-    {{!-- BEGIN-SNIPPET target-element-modal-dialog-tethered --}}
+    {{!-- BEGIN-SNIPPET target-element-modal-dialog-liquid-tether --}}
     {{#modal-dialog
         onClose='toggleTargetElement'
         hasOverlay=false
         targetAttachment=exampleTargetAttachment
         attachment=exampleAttachment
         tetherTarget="#bwtde"
+        animatable=true
     }}
       <h1>Stop! Modal Time!</h1>
       <p>Target - Element #bwtde</p>
@@ -96,15 +98,16 @@
 <div class='example'>
   <h2>Element Center</h2>
   <span id='elementCenter'>
-    <button onclick={{action (mut isShowingElementCenterModal) true}}>Element Center</button>
+    <button {{action 'toggleElementCenterModal'}}>Element Center</button>
   </span>
-  {{code-snippet name='element-centered-modal-dialog-tethered.hbs'}}
+  {{code-snippet name='element-centered-modal-dialog-liquid-tether.hbs'}}
   {{#if isShowingElementCenterModal}}
-  {{!-- BEGIN-SNIPPET element-centered-modal-dialog-tethered --}}
+  {{!-- BEGIN-SNIPPET element-centered-modal-dialog-liquid-tether --}}
     {{#modal-dialog
+        onClose='toggleElementCenterModal'
         translucentOverlay=true
         tetherTarget='#elementCenter'
-        onClose=(action (mut isShowingElementCenterModal) false)
+        animatable=true
     }}
       <p>Centered on element.</p>
     {{/modal-dialog}}

--- a/tests/dummy/app/transitions.js
+++ b/tests/dummy/app/transitions.js
@@ -1,0 +1,34 @@
+export default function() {
+  // BEGIN-SNIPPET animated-transitions
+  this.transition(
+    this.hasClass('liquid-dialog-container'),
+    this.use('explode', {
+      pick: '.ember-modal-overlay',
+      use: ['fade', { maxOpacity: 0.5 }]
+    },{
+      pick: '.ember-modal-dialog',
+      use: ['to-up']
+    })
+  );
+  // END-SNIPPET
+  // BEGIN-SNIPPET animated-with-tether-transitions
+  this.transition(
+    this.matchSelector('#modal-overlay'),
+    this.toValue((toValue, fromValue) => toValue === null || fromValue === null),
+    this.use('fade')
+  );
+
+  this.transition(
+    this.matchSelector('#modal-dialog'),
+    this.toValue((toValue, fromValue) => toValue !== null && fromValue !== null),
+    this.use('fly-to')
+  );
+
+  this.transition(
+    this.matchSelector('#modal-dialog'),
+    this.toValue((toValue, fromValue) => toValue === null || fromValue === null),
+    this.use('to-up'),
+    this.reverse('to-down')
+  );
+  // END-SNIPPET
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1354,7 +1354,7 @@ broccoli-lint-eslint@^3.3.0:
     lodash.defaultsdeep "^4.6.0"
     md5-hex "^2.0.0"
 
-broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.4:
+broccoli-merge-trees@^1.0.0, broccoli-merge-trees@^1.1.0, broccoli-merge-trees@^1.1.1, broccoli-merge-trees@^1.1.4, broccoli-merge-trees@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/broccoli-merge-trees/-/broccoli-merge-trees-1.2.4.tgz#a001519bb5067f06589d91afa2942445a2d0fdb5"
   dependencies:
@@ -1446,7 +1446,7 @@ broccoli-static-compiler@^0.1.4:
     broccoli-writer "^0.1.1"
     mkdirp "^0.3.5"
 
-broccoli-stew@^1.2.0, broccoli-stew@^1.3.3:
+broccoli-stew@^1.2.0, broccoli-stew@^1.3.3, broccoli-stew@^1.4.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/broccoli-stew/-/broccoli-stew-1.5.0.tgz#d7af8c18511dce510e49d308a62e5977f461883c"
   dependencies:
@@ -2392,7 +2392,7 @@ ember-cli-htmlbars-inline-precompile@^0.4.3:
     hash-for-dep "^1.0.2"
     silent-error "^1.1.0"
 
-ember-cli-htmlbars@^1.0.3:
+ember-cli-htmlbars@^1.0.10, ember-cli-htmlbars@^1.0.3, ember-cli-htmlbars@^1.1.1:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-1.3.2.tgz#906279c48be32986a3cc41e730ecc3513a34c4d1"
   dependencies:
@@ -2687,6 +2687,28 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-factory-for-polyfill@^1.1.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ember-factory-for-polyfill/-/ember-factory-for-polyfill-1.1.2.tgz#ea802002ec55154eea7be82abb586e77429be579"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^1.2.0"
+
+ember-getowner-polyfill@^1.1.1, ember-getowner-polyfill@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/ember-getowner-polyfill/-/ember-getowner-polyfill-1.2.3.tgz#ea70f4a48b1c05b91056371d1878bbafe018222e"
+  dependencies:
+    ember-cli-babel "^5.1.6"
+    ember-cli-version-checker "^1.2.0"
+    ember-factory-for-polyfill "^1.1.0"
+
+ember-hash-helper-polyfill@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/ember-hash-helper-polyfill/-/ember-hash-helper-polyfill-0.1.2.tgz#bc8ee6fa59e9541fce07d2cf4f263cf785e9e1db"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-cli-version-checker "^1.2.0"
+
 ember-ignore-children-helper@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-ignore-children-helper/-/ember-ignore-children-helper-1.0.0.tgz#7645d769377779ff292235725b5b1f5c2e4c16ab"
@@ -2810,6 +2832,12 @@ ember-try@^0.2.14:
     rsvp "^3.0.17"
     semver "^5.1.0"
     sync-exec "^0.6.2"
+
+ember-weakmap@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-weakmap/-/ember-weakmap-2.0.0.tgz#71c6819a8bfd0b077ae17ca1d9053fc5db06e4ac"
+  dependencies:
+    ember-cli-babel "^5.1.6"
 
 ember-wormhole@^0.5.1:
   version "0.5.1"
@@ -4377,6 +4405,42 @@ linkify-it@~1.2.0:
   dependencies:
     uc.micro "^1.0.1"
 
+liquid-fire@^0.27.3:
+  version "0.27.3"
+  resolved "https://registry.yarnpkg.com/liquid-fire/-/liquid-fire-0.27.3.tgz#483e2d4b9492c5ee6dd2c9fda5fe33a85cf0305b"
+  dependencies:
+    broccoli-funnel "^1.0.1"
+    broccoli-merge-trees "^1.0.0"
+    broccoli-stew "^1.4.2"
+    ember-cli-babel "^6.1.0"
+    ember-cli-htmlbars "^1.1.1"
+    ember-cli-version-checker "^1.2.0"
+    ember-getowner-polyfill "^1.1.1"
+    ember-hash-helper-polyfill "^0.1.2"
+    match-media "^0.2.0"
+    velocity-animate ">= 0.11.8"
+
+liquid-tether@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/liquid-tether/-/liquid-tether-2.0.4.tgz#6abcb53c3b3750d2b714a875f83de362c06e528a"
+  dependencies:
+    broccoli-funnel "^1.1.0"
+    broccoli-merge-trees "^1.2.4"
+    ember-cli-babel "^5.1.7"
+    ember-cli-htmlbars "^1.0.10"
+    liquid-wormhole "^2.0.2"
+    tether "^1.4.0"
+
+liquid-wormhole@^2.0.2, liquid-wormhole@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/liquid-wormhole/-/liquid-wormhole-2.0.5.tgz#70d346892aff649945645848962209fffb331740"
+  dependencies:
+    ember-cli-babel "^5.1.7"
+    ember-cli-htmlbars "^1.1.1"
+    ember-getowner-polyfill "^1.2.1"
+    ember-weakmap "2.0.0"
+    perf-primitives "0.0.4"
+
 livereload-js@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/livereload-js/-/livereload-js-2.2.2.tgz#6c87257e648ab475bc24ea257457edcc1f8d0bc2"
@@ -4807,6 +4871,10 @@ marked-terminal@^1.6.2:
 marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
+
+match-media@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/match-media/-/match-media-0.2.0.tgz#ea4e09742e7253cc7d7e1599ba627e0fa29fbc50"
 
 matcher-collection@^1.0.0, matcher-collection@^1.0.1:
   version "1.0.4"
@@ -5619,6 +5687,12 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+perf-primitives@0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/perf-primitives/-/perf-primitives-0.0.4.tgz#f07e7f33ef3e200393aa218f591918fb3abe46e8"
+  dependencies:
+    ember-cli-babel "^5.1.6"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -7118,6 +7192,10 @@ validate-npm-package-name@~2.2.2:
 vary@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+
+"velocity-animate@>= 0.11.8":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/velocity-animate/-/velocity-animate-1.5.0.tgz#fc8771d8dfe1136ff02a707e10fbb0957c4b030f"
 
 verror@1.3.6:
   version "1.3.6"


### PR DESCRIPTION
- To animate non-tethered cases, install `liquid-wormhole` and pass `animatable=true`
- To animate tethered cases, install `liquid-tether` and pass `animatable=true`
- See the dummy app for examples
- Note that in 3.0.0, the animatable code path will be used automatically if these libraries are present and `animatable` is unspecified. To prepare users for this, a deprecation warning is emitted if the libraries are present and `animatable` is unspecified in 2.x.
- targetAttachment of "center" and "middle center" now uses SCSS for positioning rather than dynamic rules