### PR TITLE
Typo: missing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ export default ModalDialog.extend(EmberKeyboardMixin, {
     this._super(...arguments);
 
     this.set('keyboardActivated', true);
-  }
+  },
 
   closeOnEsc: Ember.on(keyDown('Escape'), function() {
     this.sendAction('close');


### PR DESCRIPTION
Added missing ',' to code sample regarding keyboard event handling.