### PR TITLE
Don't fail if ENV['ember-modal-dialog'] is not defined

### DIFF
--- a/app/services/modal-dialog.js
+++ b/app/services/modal-dialog.js
@@ -5,7 +5,7 @@ const { computed, Service } = Ember;
 
 function computedFromConfig(prop) {
   return computed(function(){
-    return ENV['ember-modal-dialog'][prop];
+    return ENV['ember-modal-dialog'] && ENV['ember-modal-dialog'][prop];
   });
 }
 


### PR DESCRIPTION
- Hopefully restores working order in Ember Twiddle. Fixes #198.