### PR TITLE
fix(#195): provide default values for concatenatedProperties

### DIFF
--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -11,6 +11,10 @@ export default Component.extend({
   tagName: '',
   layout,
 
+  containerClassNames: null,
+  overlayClassNames: null,
+  wrapperClassNames: null,
+
   modalService: service('modal-dialog'),
   destinationElementId: computed.oneWay('modalService.destinationElementId'),
 


### PR DESCRIPTION
closes #195 

This issue affects IE 11 which is still being supported for quite some time. It seems somehow to be related to https://github.com/emberjs/ember.js/issues/14264 , though that particular issue was fixed. @PrzemoRevolve found a work around, but instead of adding empty strings for the concatenated properties every time modal-dialog is used, the work around can be implemented inside basic-dialog.js by adding default values of empty arrays to those properties.

@lukemelia this works on IE 11, <strike>do you think it will cause any unwanted side effects?</strike> with null values instead of empty arrays (which I tried first) I don't think it should cause any side effects.