### PR TITLE
Add ember-cli-version-checker as a dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "ember-cli-babel": "^6.1.0",
     "ember-cli-htmlbars": "^2.0.1",
+    "ember-cli-version-checker": "^2.1.0",
     "ember-ignore-children-helper": "^1.0.0",
     "ember-wormhole": "^0.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2573,6 +2573,13 @@ ember-cli-version-checker@^2.0.0:
     resolve "^1.3.3"
     semver "^5.3.0"
 
+ember-cli-version-checker@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-version-checker/-/ember-cli-version-checker-2.1.0.tgz#fc79a56032f3717cf844ada7cbdec1a06fedb604"
+  dependencies:
+    resolve "^1.3.3"
+    semver "^5.3.0"
+
 ember-cli@^2.13.1:
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/ember-cli/-/ember-cli-2.13.1.tgz#ac02ca2d967bb660b577286e4c88c7cea13806b3"


### PR DESCRIPTION
ember-cli-version-checker is `require`'d and used in `config/environment.js`, but it only worked because the package happened to be available via `ember-resolver`. We should list is as an explicit dependency.