### PR TITLE
Revert modules update to file in app directory

### DIFF
--- a/app/services/modal-dialog.js
+++ b/app/services/modal-dialog.js
@@ -1,6 +1,7 @@
-import { computed } from '@ember/object';
-import Service from '@ember/service';
+import Ember from 'ember';
 import ENV from '../config/environment';
+
+const { computed, Service } = Ember;
 
 function computedFromConfig(prop) {
   return computed(function(){


### PR DESCRIPTION
https://github.com/yapplabs/ember-modal-dialog/issues/231 raised an issue with the changes I made in https://github.com/yapplabs/ember-modal-dialog/pull/215.  I _should not_ have updated any files in /app since those are transpiled by the consuming app which would require them to be on ember-cli-babel 6.6 or greater.  This commit reverts that change to avoid any breaking changes for consumers of this addon who have not updated their ember-cli-babel yet. 