### PR TITLE
Remove 'target' prop from modal-dialog to resolve Ember regression

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -148,19 +148,6 @@ export default Component.extend({
   tetherTarget: null,
   stack: computed.oneWay('elementId'), // pass a `stack` string to set a "stack" to be passed to liquid-wormhole / liquid-tether
   value: 0, // pass a `value` to set a "value" to be passed to liquid-wormhole / liquid-tether
-  target: computed({ // element, css selector, or view instance
-    get() {
-      return 'body';
-    },
-    set(key, value) {
-      deprecate(
-        'Specifying a `target` on `modal-dialog` is deprecated in favor of padding `tetherTarget`, which will trigger ember-tether usage. Support for `target` will be removed in 3.0.0.',
-        false,
-        { id: 'ember-modal-dialog.modal-dialog-target', until: '3.0.0' }
-      );
-      return value;
-    },
-  }),
 
   targetAttachment: 'middle center',
   tetherClassPrefix: null,

--- a/addon/templates/components/modal-dialog.hbs
+++ b/addon/templates/components/modal-dialog.hbs
@@ -12,7 +12,7 @@
     overlayPosition=overlayPosition
 
     tetherTarget=tetherTarget
-    legacyTarget=target
+    legacyTarget='body'
     attachment=attachment
     targetAttachment=targetAttachment
     targetModifier=targetModifier


### PR DESCRIPTION
Starting in Ember 2.18, components with a `target` property defined won't propagate actions sent using `sendAction`.

Issues describing this: https://github.com/emberjs/ember.js/issues/15966, https://github.com/yapplabs/ember-modal-dialog/issues/239

`ember-modal-dialog` has `target` defined in two components: modal-dialog, and deprecated-tether-dialog. modal-dailog has had a deprecation warning on the usage of `target` for a while (https://github.com/yapplabs/ember-modal-dialog/commit/bdc03dab86c7f92457835cd2803efcc35f7f55c2), so that felt safe to remove. deprecated-tether-dialog does not have this deprecation warning, so I did not remove it there. I'm assuming that if somebody is using a deprecated dialog, they are likely also not using Ember 2.18, and hopefully wouldn't be experiencing this issue.

Even if this does not get merged in, this branch can be used by people to resolve the regression issues described above, until the regression gets fixed.