### PR TITLE
Fix bug with clickOutsideToClose when specifying a stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - yarn global add bower
 
 install:
-  - yarn install --no-lockfile
+  - yarn install --no-lockfile --ignore-engines
   - bower install
 
 script:

--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -78,8 +78,13 @@ export default Component.extend({
         return;
       }
 
+      let modalSelector = '.ember-modal-dialog';
+      if (this.get('stack')) {
+        modalSelector = '#' + this.get('stack') + modalSelector;
+      }
+
       // if the click is within the dialog, do nothing
-      if ($eventTarget.closest('.ember-modal-dialog').length) {
+      if ($eventTarget.closest(modalSelector).length) {
         return;
       }
 


### PR DESCRIPTION
This bug prevented closing the modal when a stack was specified and click target was within the modal of a separate stack.