### PR TITLE
Don't sendAction in click handler when component isDestroying or isDestroyed

### DIFF
--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -65,6 +65,10 @@ export default Component.extend({
         return;
       }
 
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
       let modalSelector = '.ember-modal-dialog';
       if (this.get('stack')) {
         modalSelector = '#' + this.get('stack') + modalSelector;


### PR DESCRIPTION
Fixes failed tests since ember 3.2.

Based on tips from this issue https://github.com/emberjs/ember.js/issues/16778