### PR TITLE
update README.md Custom Modals section

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,8 @@ export default ModalDialog.extend({
 });
 ```
 
-This can then be used like so:
+By subclassing `modal-dialog` your component will use the default modal dialog template. Therefore, you do not need to create a `app/templates/components/full-screen-modal.hbs` file.
+Your component can then be used like so:
 
 ```htmlbars
 {{#full-screen-modal}}


### PR DESCRIPTION
A `full-screen-modal` component that subclasses `modal-dialog` will not display correctly if it has a template file.