### PR TITLE
Handle when App.rootElement can be a node, rather than an id

### DIFF
--- a/addon/initializers/add-modals-container.js
+++ b/addon/initializers/add-modals-container.js
@@ -1,7 +1,7 @@
 /*globals document */
 let hasDOM = typeof document !== 'undefined';
 
-function appendContainerElement(rootElementId, id) {
+function appendContainerElement(rootElementOrId, id) {
   if (!hasDOM) {
     return;
   }
@@ -10,7 +10,7 @@ function appendContainerElement(rootElementId, id) {
     return;
   }
 
-  let rootEl = document.querySelector(rootElementId);
+  let rootEl = rootElementOrId.appendChild ? rootElementOrId : document.querySelector(rootElementOrId);
   let modalContainerEl = document.createElement('div');
   modalContainerEl.id = id;
   rootEl.appendChild(modalContainerEl);


### PR DESCRIPTION
Hi there!

It turns out that it's possible for rootElement to be a node rather than an id. An example is when running Storybook, but there are likely others. This makes sure that doesn't fail. 