### PR TITLE
fix error when no onClose callback defined

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -77,6 +77,7 @@ export default Component.extend({
   tetherTarget: null,
   stack: oneWay('elementId'), // pass a `stack` string to set a "stack" to be passed to liquid-wormhole / liquid-tether
   value: 0, // pass a `value` to set a "value" to be passed to liquid-wormhole / liquid-tether
+  onClose: function(){},
 
   targetAttachment: 'middle center',
   tetherClassPrefix: null,


### PR DESCRIPTION
When no onClose callback was defined and user clicked outside the dialog this error appeared:

```
Uncaught TypeError: this.get(...) is not a function
    at Class.onClickOverlay (modal-dialog.js:122)
    at Backburner._join (backburner.js:834)
    at Backburner.join (backburner.js:612)
    at join (index.js:164)
    at ember-glimmer.js:5252
    at flaggedInstrument (index.js:119)
    at Class.<anonymous> (ember-glimmer.js:5251)
    at Class.<anonymous> (ignore-children.js:12)
    at Backburner._run (backburner.js:851)
    at Backburner._join (backburner.js:829)
```