### PR TITLE
fixes bad css import snippet in README installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Then import the CSS files
 
 **app.css**
 ```css
-@import "ember-modal-dialog/ember-modal-structure.css";
-@import "ember-modal-dialog/ember-modal-appearance.css";
+@import "ember-modal-dialog/ember-modal-structure";
+@import "ember-modal-dialog/ember-modal-appearance";
 ```
 
 **application.hbs**


### PR DESCRIPTION
Removes the '.css' extension from the css @import links
the user is told to paste into app.css, which produce 404 errors in
a fresh install.