### PR TITLE
fixes my previous change to the css installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ Then import the CSS files
 
 **app.css**
 ```css
+@import "ember-modal-dialog/ember-modal-structure.css";
+@import "ember-modal-dialog/ember-modal-appearance.css";
+```
+
+If you’re using SASS then just import the CSS slightly differently
+
+**app.scss**
+```scss
 @import "ember-modal-dialog/ember-modal-structure";
 @import "ember-modal-dialog/ember-modal-appearance";
 ```


### PR DESCRIPTION
There are two places in the README where the user is told how to install CSS.
The first place is more of a quick start guide and only shows how to import
using regular CSS. The second place shows how to import both CSS and SASS.

As a SASS user installing the addon it is easy to not notice the second section and get tripped up
and use the CSS imports instead of the SASS imports, as I did, and never notice the second section in the README.

This commit reverts an earlier change I made and copies the SASS instructions to
the Quickstart section.