### PR TITLE
Backport isDestroying check in handleClick (from 2d83a7af)

### DIFF
--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -64,6 +64,10 @@ export default Component.extend({
         return;
       }
 
+      if (this.isDestroying || this.isDestroyed) {
+        return;
+      }
+
       let modalSelector = '.ember-modal-dialog';
       if (this.get('stack')) {
         modalSelector = '#' + this.get('stack') + modalSelector;


### PR DESCRIPTION
In Ember tests, because the handleClick is registered inside a 'setTimeout' (which is not subject to wait()/settled()), it is possible for the addEventListener to happen AFTER the willDestroy/removeEventListener; leading to blowups in the handleClick (destroyed component).

This can lead to test blowups that are very hard to track down (since they appear to occur randomly in a later test).  A simple isDestroyed test works wonders.

Backported from commit 2d83a7afc0ef68d7abfa65891ea4a0fbb0e5fa89