### PR TITLE
check type function for action callbacks

### DIFF
--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -2,7 +2,7 @@ import { oneWay, readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
 import { dasherize } from '@ember/string';
 import { computed } from '@ember/object';
-import { isEmpty } from '@ember/utils';
+import { isEmpty, typeOf } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/modal-dialog';
 import { warn } from '@ember/debug';
@@ -110,16 +110,16 @@ export default Component.extend({
   },
   actions: {
     onClose() {
-      if (this.get('onClose')) {
+      if (typeOf(this.get('onClose')) === 'function') {
         this.get('onClose')();
       }
     },
     onClickOverlay(e) {
       e.preventDefault();
-      if (this.get('onClickOverlay')) {
+      if (typeof(this.get('onClickOverlay')) === 'function') {
         this.get('onClickOverlay')();
       } else {
-        if (this.get('onClose')) {
+        if (typeof(this.get('onClose')) === 'function') {
           this.get('onClose')();
         }
       }

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -5,7 +5,7 @@ import { computed } from '@ember/object';
 import { isEmpty, typeOf, isNone } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/modal-dialog';
-import { warn } from '@ember/debug';
+import { assert, warn } from '@ember/debug';
 import { DEBUG } from '@glimmer/env';
 
 const VALID_OVERLAY_POSITIONS = ['parent', 'sibling'];
@@ -112,29 +112,27 @@ export default Component.extend({
     onClose() {
       const onClose = this.get('onClose');
       // we shouldn't warn if the callback is not provided at all
-      if (!isNone(onClose)) {
-        if (typeOf(onClose) === 'function') {
-          onClose();
-        } else {
-          warn('onClose handler must be a function', false, { id: 'ember-modal-dialog.on-close' })
-        }
+      if (isNone(onClose)) {
+        return;
       }
+
+      assert('onClose handler must be a function', typeOf(onClose) === 'function');
+
+      onClose();
     },
     onClickOverlay(e) {
       e.preventDefault();
 
       const onClickOverlay = this.get('onClickOverlay');
       // we shouldn't warn if the callback is not provided at all
-      if (!isNone(onClickOverlay)) {
-        if (typeof(onClickOverlay) === 'function') {
-          onClickOverlay();
-        } else {
-          warn('onClickOverlay handler must be a function', false, { id: 'ember-modal-dialog.on-click-overlay' })
-        }
-      } else {
-        // call close action
+      if (isNone(onClickOverlay)) {
         this.send('onClose');
+        return;
       }
+
+      assert('onClickOverlay handler must be a function', typeOf(onClickOverlay) === 'function');
+
+      onClickOverlay();
     }
   }
 });

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -2,7 +2,7 @@ import { oneWay, readOnly } from '@ember/object/computed';
 import Component from '@ember/component';
 import { dasherize } from '@ember/string';
 import { computed } from '@ember/object';
-import { isEmpty, typeOf } from '@ember/utils';
+import { isEmpty, typeOf, isNone } from '@ember/utils';
 import { inject as service } from '@ember/service';
 import layout from '../templates/components/modal-dialog';
 import { warn } from '@ember/debug';
@@ -110,18 +110,30 @@ export default Component.extend({
   },
   actions: {
     onClose() {
-      if (typeOf(this.get('onClose')) === 'function') {
-        this.get('onClose')();
+      const onClose = this.get('onClose');
+      // we shouldn't warn if the callback is not provided at all
+      if (!isNone(onClose)) {
+        if (typeOf(onClose) === 'function') {
+          onClose();
+        } else {
+          warn('onClose handler must be a function', false, { id: 'ember-modal-dialog.on-close' })
+        }
       }
     },
     onClickOverlay(e) {
       e.preventDefault();
-      if (typeof(this.get('onClickOverlay')) === 'function') {
-        this.get('onClickOverlay')();
-      } else {
-        if (typeof(this.get('onClose')) === 'function') {
-          this.get('onClose')();
+
+      const onClickOverlay = this.get('onClickOverlay');
+      // we shouldn't warn if the callback is not provided at all
+      if (!isNone(onClickOverlay)) {
+        if (typeof(onClickOverlay) === 'function') {
+          onClickOverlay();
+        } else {
+          warn('onClickOverlay handler must be a function', false, { id: 'ember-modal-dialog.on-click-overlay' })
         }
+      } else {
+        // call close action
+        this.send('onClose');
       }
     }
   }


### PR DESCRIPTION
I accidentally gave callback as a string rather than function, the app broke, I think its good to check action type is a function before calling it