### PR TITLE
Remove obsolete `this.get(...)` calls

### DIFF
--- a/addon/components/basic-dialog.js
+++ b/addon/components/basic-dialog.js
@@ -17,33 +17,33 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    if (!this.get('destinationElementId')) {
-      this.set('destinationElementId', this.get('modalService.destinationElementId'));
+    if (!this.destinationElementId) {
+      this.set('destinationElementId', this.modalService.destinationElementId);
     }
   },
 
   variantWrapperClass: 'emd-static',
   containerClassNamesString: computed('containerClassNames.[]', 'targetAttachmentClass', 'attachmentClass', 'containerClass', function() {
     return [
-      this.get('containerClassNames').join(' '),
-      this.get('targetAttachmentClass'),
-      this.get('attachmentClass'),
-      this.get('containerClass')
+      this.containerClassNames.join(' '),
+      this.targetAttachmentClass,
+      this.attachmentClass,
+      this.containerClass
     ].filter((className) => !isEmpty(className)).join(' ');
   }),
   overlayClassNamesString: computed('overlayClassNames.[]', 'overlayClass', 'translucentOverlay', function(){
     return [
-      this.get('overlayClassNames').join(' '),
-      this.get('translucentOverlay') ? 'translucent' : null,
-      this.get('overlayClass')
+      this.overlayClassNames.join(' '),
+      this.translucentOverlay ? 'translucent' : null,
+      this.overlayClass
     ].filter((className) => !isEmpty(className)).join(' ');
   }),
   wrapperClassNamesString: computed('wrapperClassNames.[]', 'targetAttachmentClass', 'variantWrapperClass', 'wrapperClass', function(){
     return [
-      this.get('wrapperClassNames').join(' '),
-      this.get('targetAttachmentClass').replace('emd-', 'emd-wrapper-'),
-      this.get('variantWrapperClass'),
-      this.get('wrapperClass')
+      this.wrapperClassNames.join(' '),
+      this.targetAttachmentClass.replace('emd-', 'emd-wrapper-'),
+      this.variantWrapperClass,
+      this.wrapperClass
     ].filter((className) => !isEmpty(className)).join(' ');
   }),
 
@@ -55,11 +55,11 @@ export default Component.extend({
   isCentered: true,
   overlayPosition: null,
   isOverlaySibling: computed('overlayPosition', function() {
-    return this.get('overlayPosition') === 'sibling';
+    return this.overlayPosition === 'sibling';
   }),
 
   didInsertElement() {
-    if (!this.get('clickOutsideToClose')) {
+    if (!this.clickOutsideToClose) {
       return;
     }
     this.makeOverlayClickableOnIOS();
@@ -76,8 +76,8 @@ export default Component.extend({
       }
 
       let modalSelector = '.ember-modal-dialog';
-      if (this.get('stack')) {
-        modalSelector = '#' + this.get('stack') + modalSelector;
+      if (this.stack) {
+        modalSelector = '#' + this.stack + modalSelector;
       }
 
       // if the click is within the dialog, do nothing
@@ -85,8 +85,8 @@ export default Component.extend({
       if (modalEl && modalEl.contains(target)) {
         return;
       }
-      if (this.get('onClose')) {
-        this.get('onClose')();
+      if (this.onClose) {
+        this.onClose();
       }
     };
 
@@ -95,7 +95,7 @@ export default Component.extend({
     // setTimeout needed or else the click handler will catch the click that spawned this modal dialog
     setTimeout(registerClick);
 
-    if (this.get('isIOS')) {
+    if (this.isIOS) {
       const registerTouch = () => document.addEventListener('touchend', this.handleClick);
       setTimeout(registerTouch);
     }
@@ -104,7 +104,7 @@ export default Component.extend({
 
   willDestroyElement() {
     document.removeEventListener('click', this.handleClick);
-    if (this.get('isIOS')) {
+    if (this.isIOS) {
       document.removeEventListener('touchend', this.handleClick);
     }
     this._super(...arguments);
@@ -115,7 +115,7 @@ export default Component.extend({
   }),
 
   makeOverlayClickableOnIOS: function() {
-    if (this.get('isIOS')) {
+    if (this.isIOS) {
       let overlayEl = document.querySelector('div[data-emd-overlay]');
       if (overlayEl) {
         overlayEl.style.cursor = 'pointer';

--- a/addon/components/liquid-tether-dialog.js
+++ b/addon/components/liquid-tether-dialog.js
@@ -7,7 +7,7 @@ export default BasicDialog.extend({
   layout,
 
   targetAttachmentClass: computed('targetAttachment', function() {
-    let targetAttachment = this.get('targetAttachment') || '';
+    let targetAttachment = this.targetAttachment || '';
     return `ember-modal-dialog-target-attachment-${dasherize(targetAttachment)}`;
   }),
 
@@ -15,10 +15,10 @@ export default BasicDialog.extend({
   attachment: null,
   didReceiveAttrs() {
     this._super(...arguments);
-    if (!this.get('attachment')) {
+    if (!this.attachment) {
       this.set('attachment', 'middle center');
     }
-    if (!this.get('targetAttachment')) {
+    if (!this.targetAttachment) {
       this.set('targetAttachment', 'middle center');
     }
   },

--- a/addon/components/modal-dialog.js
+++ b/addon/components/modal-dialog.js
@@ -18,18 +18,18 @@ export default Component.extend({
 
   init() {
     this._super(...arguments);
-    if (!this.get('destinationElementId')) {
-      this.set('destinationElementId', this.get('modalService.destinationElementId'));
+    if (!this.destinationElementId) {
+      this.set('destinationElementId', this.modalService.destinationElementId);
     }
   },
 
   modalDialogComponentName: computed('renderInPlace', 'tetherTarget', 'animatable', 'hasLiquidWormhole', 'hasLiquidTether', function(){
-    let tetherTarget = this.get('tetherTarget');
-    let hasLiquidTether = this.get('hasLiquidTether');
-    let hasLiquidWormhole = this.get('hasLiquidWormhole');
-    let animatable = this.get('animatable');
+    let tetherTarget = this.tetherTarget;
+    let hasLiquidTether = this.hasLiquidTether;
+    let hasLiquidWormhole = this.hasLiquidWormhole;
+    let animatable = this.animatable;
 
-    if (this.get('renderInPlace')) {
+    if (this.renderInPlace) {
       return 'ember-modal-dialog/-in-place-dialog';
     } else if (tetherTarget && hasLiquidTether && hasLiquidWormhole && animatable === true) {
       return 'ember-modal-dialog/-liquid-tether-dialog';
@@ -52,7 +52,7 @@ export default Component.extend({
     }
   },
   validateProps() {
-    let overlayPosition = this.get('overlayPosition');
+    let overlayPosition = this.overlayPosition;
     if (VALID_OVERLAY_POSITIONS.indexOf(overlayPosition) === -1) {
       warn(
         `overlayPosition value '${overlayPosition}' is not valid (valid values [${VALID_OVERLAY_POSITIONS.join(', ')}])`,
@@ -89,7 +89,7 @@ export default Component.extend({
   targetAttachment: 'middle center',
   tetherClassPrefix: null,
   attachmentClass: computed('attachment', function() {
-    let attachment = this.get('attachment');
+    let attachment = this.attachment;
     if (isEmpty(attachment)) {
       return;
     }
@@ -98,19 +98,19 @@ export default Component.extend({
     }).join(' ');
   }),
   targetAttachmentClass: computed('targetAttachment', function() {
-    let targetAttachment = this.get('targetAttachment') || '';
+    let targetAttachment = this.targetAttachment || '';
     // Convert tether-styled values like 'middle right' to 'right'
     targetAttachment = targetAttachment.split(' ').slice(-1)[0];
     return `ember-modal-dialog-target-attachment-${dasherize(targetAttachment)} emd-target-attachment-${dasherize(targetAttachment)}`;
   }),
   ensureEmberTetherPresent() {
-    if (!this.get('modalService.hasEmberTether')) {
+    if (!this.modalService.hasEmberTether) {
       throw new Error('Please install ember-tether in order to pass a tetherTarget to modal-dialog');
     }
   },
   actions: {
     onClose() {
-      const onClose = this.get('onClose');
+      const onClose = this.onClose;
       // we shouldn't warn if the callback is not provided at all
       if (isNone(onClose)) {
         return;
@@ -123,7 +123,7 @@ export default Component.extend({
     onClickOverlay(e) {
       e.preventDefault();
 
-      const onClickOverlay = this.get('onClickOverlay');
+      const onClickOverlay = this.onClickOverlay;
       // we shouldn't warn if the callback is not provided at all
       if (isNone(onClickOverlay)) {
         this.send('onClose');

--- a/addon/components/positioned-container.js
+++ b/addon/components/positioned-container.js
@@ -17,11 +17,11 @@ export default Component.extend({
   targetAttachment: 'center',
 
   isPositioned: computed('targetAttachment', 'target', 'renderInPlace', function() {
-    if (this.get('renderInPlace')) {
+    if (this.renderInPlace) {
       return false;
     }
-    let target = this.get('target');
-    let targetAttachment = this.get('targetAttachment');
+    let target = this.target;
+    let targetAttachment = this.targetAttachment;
     if (target === 'body' && (targetAttachment === 'center' || targetAttachment === 'middle center')) {
       return false;
     }
@@ -38,7 +38,7 @@ export default Component.extend({
       return;
     }
 
-    if (this.get('isPositioned')) {
+    if (this.isPositioned) {
       this.updateTargetAttachment();
     } else {
       this.element.style.left = '';
@@ -47,7 +47,7 @@ export default Component.extend({
   })),
 
   getWrappedTargetAttachmentElement() {
-    const target = this.get('target');
+    const target = this.target;
     if (!target) {
       return null;
     }
@@ -69,7 +69,7 @@ export default Component.extend({
   },
 
   updateTargetAttachment() {
-    let targetAttachment = this.get('targetAttachment');
+    let targetAttachment = this.targetAttachment;
     // Convert tether-styled values like 'middle right' to 'right'
     targetAttachment = targetAttachment.split(' ').slice(-1)[0];
     assert(

--- a/addon/components/tether-dialog.js
+++ b/addon/components/tether-dialog.js
@@ -10,7 +10,7 @@ export default BasicDialog.extend({
     this._ensureAttachments();
   },
   targetAttachmentClass: computed('targetAttachment', function() {
-    let targetAttachment = this.get('targetAttachment') || '';
+    let targetAttachment = this.targetAttachment || '';
     return `ember-modal-dialog-target-attachment-${dasherize(targetAttachment)}`;
   }),
 
@@ -35,10 +35,10 @@ export default BasicDialog.extend({
   // targetOffset - passed in
   // targetModifier - passed in
   _ensureAttachments() {
-    if (!this.get('attachment')) {
+    if (!this.attachment) {
       this.set('attachment', 'middle center');
     }
-    if (!this.get('targetAttachment')) {
+    if (!this.targetAttachment) {
       this.set('targetAttachment', 'middle center');
     }
   }


### PR DESCRIPTION
see https://blog.emberjs.com/ember-3-1-beta-released/#toc_es5-getters-for-computed-properties

This will probably require us to bump the minimum supported Ember version though, but since v3.1 was released over three years ago (😱), I guess that is fine by now?