### PR TITLE
Add ember-tether as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
   "peerDependencies": {
     "ember-tether": "^2.0.1"
   },
+  "peerDependenciesMeta": {
+    "ember-tether": {
+      "optional": true
+    }
+  },
   "resolutions": {
     "**/@embroider/macros": "^1.0.0",
     "**/@embroider/util": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
     "release-it-lerna-changelog": "^2.3.0",
     "webpack": "^5.67.0"
   },
+  "peerDependencies": {
+    "ember-tether": "^2.0.1"
+  },
   "resolutions": {
     "**/@embroider/macros": "^1.0.0",
     "**/@embroider/util": "^1.0.0"


### PR DESCRIPTION
This should help with embroider issues. Embroider does not like when there are imports from a package that is not a dependency of some kind.