### PR TITLE
Add splattibutes support and fix containerClassNames for rendered in place modals

### DIFF
--- a/addon/components/in-place-dialog.js
+++ b/addon/components/in-place-dialog.js
@@ -5,23 +5,18 @@ import layout from '../templates/components/in-place-dialog';
 @tagName('')
 @templateLayout(layout)
 export default class InPlaceDialog extends Component {
-  containerClass = null; // passed in
-
-  init() {
-    super.init(...arguments);
-
-    this.containerClassNames = [
+  get containerClassNamesString() {
+    const addonClassNamesString = [
       'ember-modal-dialog',
       'ember-modal-dialog-in-place',
       'emd-in-place',
-    ]; // set this in a subclass definition
-  }
+    ].join(' ');
 
-  get containerClassNamesString() {
-    return (
+    const containerClassNamesString =
       (this.containerClassNames?.join && this.containerClassNames?.join(' ')) ||
       this.containerClassNames ||
-      ''
-    );
+      '';
+
+    return `${addonClassNamesString} ${containerClassNamesString}`;
   }
 }

--- a/addon/templates/components/basic-dialog.hbs
+++ b/addon/templates/components/basic-dialog.hbs
@@ -1,34 +1,49 @@
 <EmberWormhole @to={{this.destinationElementId}}>
   {{#if this.isOverlaySibling}}
-    <div class="{{this.wrapperClassNamesString}} {{this.wrapperClass}}">
+    <div class='{{this.wrapperClassNamesString}} {{this.wrapperClass}}'>
       {{#if this.hasOverlay}}
         <div
           class={{this.overlayClassNamesString}}
           onclick={{action this.onClickOverlay}}
-          tabindex="-1"
+          tabindex='-1'
           data-emd-overlay
         >
         </div>
       {{/if}}
-      <EmberModalDialogPositionedContainer @class={{this.containerClassNamesString}} @targetAttachment={{this.targetAttachment}} @target={{this.legacyTarget}}>
+      <EmberModalDialogPositionedContainer
+        @class={{this.containerClassNamesString}}
+        @targetAttachment={{this.targetAttachment}}
+        @target={{this.legacyTarget}}
+        ...attributes
+      >
         {{yield}}
       </EmberModalDialogPositionedContainer>
     </div>
   {{else}}
-    <div class="{{this.wrapperClassNamesString}} {{this.wrapperClass}}">
+    <div class='{{this.wrapperClassNamesString}} {{this.wrapperClass}}'>
       {{#if this.hasOverlay}}
         <div
           class={{this.overlayClassNamesString}}
           onclick={{action (ignore-children this.onClickOverlay)}}
-          tabindex="-1"
+          tabindex='-1'
           data-emd-overlay
         >
-          <EmberModalDialogPositionedContainer @class={{this.containerClassNamesString}} @targetAttachment={{this.targetAttachment}} @target={{this.legacyTarget}}>
+          <EmberModalDialogPositionedContainer
+            @class={{this.containerClassNamesString}}
+            @targetAttachment={{this.targetAttachment}}
+            @target={{this.legacyTarget}}
+            ...attributes
+          >
             {{yield}}
           </EmberModalDialogPositionedContainer>
         </div>
       {{else}}
-        <EmberModalDialogPositionedContainer @class={{this.containerClassNamesString}} @targetAttachment={{this.targetAttachment}} @target={{this.legacyTarget}}>
+        <EmberModalDialogPositionedContainer
+          @class={{this.containerClassNamesString}}
+          @targetAttachment={{this.targetAttachment}}
+          @target={{this.legacyTarget}}
+          ...attributes
+        >
           {{yield}}
         </EmberModalDialogPositionedContainer>
       {{/if}}

--- a/addon/templates/components/in-place-dialog.hbs
+++ b/addon/templates/components/in-place-dialog.hbs
@@ -1,3 +1,12 @@
-<div class={{concat this.containerClassNamesString " " this.attachmentClass " " this.containerClass}}>
+<div
+  class={{concat
+    this.containerClassNamesString
+    ' '
+    this.attachmentClass
+    ' '
+    this.containerClass
+  }}
+  ...attributes
+>
   {{yield}}
 </div>

--- a/addon/templates/components/in-place-dialog.hbs
+++ b/addon/templates/components/in-place-dialog.hbs
@@ -1,5 +1,3 @@
-<div
-  class={{concat this.containerClassNamesString " " this.attachmentClass " " this.containerClass}}
->
+<div class={{concat this.containerClassNamesString " " this.attachmentClass " " this.containerClass}}>
   {{yield}}
 </div>

--- a/addon/templates/components/liquid-dialog.hbs
+++ b/addon/templates/components/liquid-dialog.hbs
@@ -1,35 +1,53 @@
 {{#if this.isOverlaySibling}}
-  <LiquidWormhole @stack={{this.stack}} @value={{this.value}} @class={{concat "liquid-dialog-container " this.wrapperClassNamesString " " this.wrapperClass}}>
-    <div class="{{this.wrapperClassNamesString}} {{this.wrapperClass}}">
+  <LiquidWormhole
+    @stack={{this.stack}}
+    @value={{this.value}}
+    @class={{concat
+      'liquid-dialog-container '
+      this.wrapperClassNamesString
+      ' '
+      this.wrapperClass
+    }}
+  >
+    <div class='{{this.wrapperClassNamesString}} {{this.wrapperClass}}'>
       {{#if this.hasOverlay}}
         <div
           class={{this.overlayClassNamesString}}
           onclick={{action this.onClickOverlay}}
-          tabindex="-1"
+          tabindex='-1'
           data-emd-overlay
         >
         </div>
       {{/if}}
-      <div class={{this.containerClassNamesString}}>
+      <div class={{this.containerClassNamesString}} ...attributes>
         {{yield}}
       </div>
     </div>
   </LiquidWormhole>
 {{else}}
-  <LiquidWormhole @stack={{this.stack}} @value={{this.value}} @class={{concat "liquid-dialog-container " this.wrapperClassNamesString " " this.wrapperClass}}>
+  <LiquidWormhole
+    @stack={{this.stack}}
+    @value={{this.value}}
+    @class={{concat
+      'liquid-dialog-container '
+      this.wrapperClassNamesString
+      ' '
+      this.wrapperClass
+    }}
+  >
     {{#if this.hasOverlay}}
       <div
         class={{this.overlayClassNamesString}}
         onclick={{action (ignore-children this.onClickOverlay)}}
-        tabindex="-1"
+        tabindex='-1'
         data-emd-overlay
       >
-        <div class={{this.containerClassNamesString}}>
+        <div class={{this.containerClassNamesString}} ...attributes>
           {{yield}}
         </div>
       </div>
     {{else}}
-      <div class={{this.containerClassNamesString}}>
+      <div class={{this.containerClassNamesString}} ...attributes>
         {{yield}}
       </div>
     {{/if}}

--- a/addon/templates/components/liquid-tether-dialog.hbs
+++ b/addon/templates/components/liquid-tether-dialog.hbs
@@ -1,14 +1,27 @@
 {{#if this.hasOverlay}}
-  <LiquidWormhole @stack="modal-overlay" @class="liquid-dialog-container">
+  <LiquidWormhole @stack='modal-overlay' @class='liquid-dialog-container'>
     <div
       class={{this.overlayClassNamesString}}
       onclick={{action this.onClickOverlay}}
-      tabindex="-1"
+      tabindex='-1'
       data-emd-overlay
     >
     </div>
   </LiquidWormhole>
 {{/if}}
-<LiquidTether @class={{this.containerClassNamesString}} @target={{this.tetherTarget}} @attachment={{this.attachment}} @targetAttachment={{this.targetAttachment}} @targetModifier={{this.targetModifier}} @classPrefix={{this.tetherClassPrefix}} @offset={{this.offset}} @targetOffset={{this.targetOffset}} @constraints={{this.constraints}} @stack={{this.stack}} @value={{this.value}}>
+<LiquidTether
+  @class={{this.containerClassNamesString}}
+  @target={{this.tetherTarget}}
+  @attachment={{this.attachment}}
+  @targetAttachment={{this.targetAttachment}}
+  @targetModifier={{this.targetModifier}}
+  @classPrefix={{this.tetherClassPrefix}}
+  @offset={{this.offset}}
+  @targetOffset={{this.targetOffset}}
+  @constraints={{this.constraints}}
+  @stack={{this.stack}}
+  @value={{this.value}}
+  ...attributes
+>
   {{yield}}
 </LiquidTether>

--- a/addon/templates/components/modal-dialog.hbs
+++ b/addon/templates/components/modal-dialog.hbs
@@ -24,6 +24,7 @@
   @value={{this.value}}
   @onClickOverlay={{this.onClickOverlayAction}}
   @onClose={{this.onCloseAction}}
+  ...attributes
 >
   {{yield}}
 </this.whichModalDialogComponent>

--- a/addon/templates/components/tether-dialog.hbs
+++ b/addon/templates/components/tether-dialog.hbs
@@ -3,12 +3,23 @@
     <div
       class={{this.overlayClassNamesString}}
       onclick={{action this.onClickOverlay}}
-      tabindex="-1"
+      tabindex='-1'
       data-emd-overlay
     >
     </div>
   </EmberWormhole>
 {{/if}}
-<EmberTether @class={{this.containerClassNamesString}} @target={{this.tetherTarget}} @attachment={{this.attachment}} @targetAttachment={{this.targetAttachment}} @targetModifier={{this.targetModifier}} @classPrefix={{this.tetherClassPrefix}} @offset={{this.offset}} @targetOffset={{this.targetOffset}} @constraints={{this.constraints}}>
+<EmberTether
+  @class={{this.containerClassNamesString}}
+  @target={{this.tetherTarget}}
+  @attachment={{this.attachment}}
+  @targetAttachment={{this.targetAttachment}}
+  @targetModifier={{this.targetModifier}}
+  @classPrefix={{this.tetherClassPrefix}}
+  @offset={{this.offset}}
+  @targetOffset={{this.targetOffset}}
+  @constraints={{this.constraints}}
+  ...attributes
+>
   {{yield}}
 </EmberTether>

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -27,12 +27,26 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-basic button',
       dialogText: 'Basic',
       closeSelector: overlaySelector,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
 
     await assert.dialogOpensAndCloses({
       openSelector: '#example-basic button',
       dialogText: 'Basic',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -41,12 +55,26 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-translucent button',
       dialogText: 'With Translucent Overlay',
       closeSelector: overlaySelector,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
 
     await assert.dialogOpensAndCloses({
       openSelector: '#example-translucent button',
       dialogText: 'With Translucent Overlay',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -55,12 +83,26 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-without-overlay button',
       dialogText: 'Without Overlay',
       closeSelector: '#example-without-overlay',
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
 
     await assert.dialogOpensAndCloses({
       openSelector: '#example-without-overlay button',
       dialogText: 'Without Overlay',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -69,12 +111,26 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-translucent button',
       dialogText: 'With Translucent Overlay',
       closeSelector: overlaySelector,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
 
     await assert.dialogOpensAndCloses({
       openSelector: '#example-translucent button',
       dialogText: 'With Translucent Overlay',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -83,12 +139,26 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-overlay-sibling button',
       dialogText: 'With Translucent Overlay as Sibling',
       closeSelector: overlaySelector,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
 
     await assert.dialogOpensAndCloses({
       openSelector: '#example-overlay-sibling button',
       dialogText: 'With Translucent Overlay as Sibling',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -121,12 +191,24 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
             'custom-styles-modal-container',
             'has provided container-class'
           );
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
       },
     });
     await assert.dialogOpensAndCloses({
       openSelector: '#example-custom-styles button',
       dialogText: 'Custom Styles',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -142,6 +224,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
             'ember-modal-dialog-target-attachment-left',
             'has targetAttachment class name'
           );
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
       },
     });
   });
@@ -151,6 +238,13 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       openSelector: '#example-target-element button',
       dialogText: 'Target - Element',
       closeSelector: dialogCloseButton,
+      whileOpen: async function () {
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
+      },
     });
   });
 
@@ -163,6 +257,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
         assert
           .dom(dialogSelector)
           .hasClass('my-cool-modal', 'has provided containerClassNames');
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
       },
     });
   });
@@ -179,6 +278,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
         assert
           .dom(dialogSelector)
           .hasClass('my-cool-modal-2', 'has provided containerClassNames');
+        assert.hasDataTest(
+          dialogSelector,
+          'my-data-test',
+          'dialog has data-test attribute'
+        );
       },
     });
   });
@@ -198,6 +302,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
     assert
       .dom(inPlaceDialogSelector)
       .hasClass('my-custom-class', 'has provided containerClass');
+    assert.hasDataTest(
+      inPlaceDialogSelector,
+      'my-data-test',
+      'dialog has data-test attribute'
+    );
     assert.strictEqual(
       getComputedStyle(dialogElement).getPropertyValue('position'),
       'static',
@@ -247,6 +356,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
     assert
       .dom(inPlaceDialogSelector)
       .hasClass('my-custom-class-2', 'has provided containerClassNames');
+    assert.hasDataTest(
+      inPlaceDialogSelector,
+      'my-data-test',
+      'dialog has data-test attribute'
+    );
     await click(inPlaceCloseButton);
   });
 });

--- a/tests/acceptance/basic-test.js
+++ b/tests/acceptance/basic-test.js
@@ -193,8 +193,11 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       inPlaceDialogSelector,
       'button',
     ].join(' ');
-    let dialogElement = find(dialogSelector);
+    let dialogElement = find(inPlaceDialogSelector);
 
+    assert
+      .dom(inPlaceDialogSelector)
+      .hasClass('my-custom-class', 'has provided containerClass');
     assert.strictEqual(
       getComputedStyle(dialogElement).getPropertyValue('position'),
       'static',
@@ -231,5 +234,19 @@ module('Acceptance: modal-dialog | no animation, no tether', function (hooks) {
       undefined,
       'dialog is not rendered in place'
     );
+
+    await click('#example-in-place-2 button');
+    inPlaceDialogSelector = `${dialogSelector}.ember-modal-dialog-in-place`;
+    inPlaceRootSelector = '#container-in-place-2';
+    inPlaceCloseButton = [
+      inPlaceRootSelector,
+      inPlaceDialogSelector,
+      'button',
+    ].join(' ');
+
+    assert
+      .dom(inPlaceDialogSelector)
+      .hasClass('my-custom-class-2', 'has provided containerClassNames');
+    await click(inPlaceCloseButton);
   });
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -16,7 +16,7 @@
   <CodeSnippet @name="basic-modal-dialog.hbs" />
   {{#if this.isShowingBasic}}
     {{!-- BEGIN-SNIPPET basic-modal-dialog --}}
-    <ModalDialog @onClose={{action (mut this.isShowingBasic) false}}>
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingBasic) false}}>
       <h1>Stop! Modal Time!</h1>
       <p>Basic</p>
       <button onclick={{action (mut this.isShowingBasic) false}}>Close</button>
@@ -31,7 +31,7 @@
   <CodeSnippet @name="translucent-modal-dialog.hbs" />
   {{#if this.isShowingTranslucent}}
     {{!-- BEGIN-SNIPPET translucent-modal-dialog --}}
-    <ModalDialog @onClose={{action (mut this.isShowingTranslucent) false}} @translucentOverlay={{true}}>
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingTranslucent) false}} @translucentOverlay={{true}}>
       <h1>Stop! Modal Time!</h1>
       <p>With Translucent Overlay</p>
       <button onclick={{action (mut this.isShowingTranslucent) false}}>Close</button>
@@ -46,7 +46,7 @@
   <CodeSnippet @name="translucent-modal-dialog-with-callback.hbs" />
   {{#if this.isShowingTranslucentWithCallback}}
     {{!-- BEGIN-SNIPPET translucent-modal-dialog-with-callback --}}
-    <ModalDialog @onClose={{action (mut this.isShowingTranslucentWithCallback) false}} @translucentOverlay={{true}} @onClickOverlay={{action "clickedTranslucentOverlay"}}>
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingTranslucentWithCallback) false}} @translucentOverlay={{true}} @onClickOverlay={{action "clickedTranslucentOverlay"}}>
       <h1>Stop! Modal Time!</h1>
       <p>Translucent Overlay with Callback</p>
       <button onclick={{action (mut this.isShowingTranslucentWithCallback) false}}>Close</button>
@@ -61,7 +61,7 @@
   <CodeSnippet @name="modal-dialog-without-overlay.hbs" />
   {{#if this.isShowingWithoutOverlay}}
     {{!-- BEGIN-SNIPPET modal-dialog-without-overlay --}}
-    <ModalDialog @onClose={{action (mut this.isShowingWithoutOverlay) false}} @hasOverlay={{false}} @clickOutsideToClose={{true}}>
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingWithoutOverlay) false}} @hasOverlay={{false}} @clickOutsideToClose={{true}}>
       <h1>Stop! Modal Time!</h1>
       <p>Without Overlay</p>
       <button onclick={{action (mut this.isShowingWithoutOverlay) false}}>Close</button>
@@ -76,7 +76,7 @@
   <CodeSnippet @name="translucent-modal-dialog-sibling.hbs" />
   {{#if this.isShowingSibling}}
     {{!-- BEGIN-SNIPPET translucent-modal-dialog-sibling --}}
-    <ModalDialog @onClose={{action (mut this.isShowingSibling) false}} @translucentOverlay={{true}} @overlayPosition="sibling">
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingSibling) false}} @translucentOverlay={{true}} @overlayPosition="sibling">
       <h1>Stop! Modal Time!</h1>
       <p>With Translucent Overlay as Sibling</p>
       <button onclick={{action (mut this.isShowingSibling) false}}>Close</button>
@@ -92,7 +92,7 @@
   <CodeSnippet @name="custom-styles.scss" />
   {{#if this.isShowingCustomStyles}}
     {{!-- BEGIN-SNIPPET custom-styles-modal-dialog --}}
-    <ModalDialog @onClose={{action (mut this.isShowingCustomStyles) false}} @targetAttachment="none" @containerClass={{this.customContainerClassNames}} @overlayClass="custom-styles-overlay">
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingCustomStyles) false}} @targetAttachment="none" @containerClass={{this.customContainerClassNames}} @overlayClass="custom-styles-overlay">
       <h1>Stop! Modal Time!</h1>
       <p>Custom Styles</p>
       <button onclick={{action (mut this.isShowingCustomStyles) false}}>Close</button>
@@ -109,7 +109,7 @@
   <CodeSnippet @name="target-selector-modal-dialog.hbs" />
   {{#if this.isShowingTargetSelector}}
     {{!-- BEGIN-SNIPPET target-selector-modal-dialog --}}
-    <ModalDialog @onClose={{action "toggleTargetSelector"}} @targetAttachment={{this.exampleTargetAttachment}} @attachment={{this.exampleAttachment}} @target="#alignModalDialogToMe">
+    <ModalDialog data-test="my-data-test" @onClose={{action "toggleTargetSelector"}} @targetAttachment={{this.exampleTargetAttachment}} @attachment={{this.exampleAttachment}} @target="#alignModalDialogToMe">
       <h1>Stop! Modal Time!</h1>
       <p>Target - Selector: "#alignModalDialogToMe"</p>
       <p>Target Attachment: {{this.exampleTargetAttachment}}</p>
@@ -130,7 +130,7 @@
   <CodeSnippet @name="target-element-modal-dialog.hbs" />
   {{#if this.isShowingTargetElement}}
     {{!-- BEGIN-SNIPPET target-element-modal-dialog --}}
-    <ModalDialog @onClose={{action "toggleTargetElement"}} @targetAttachment={{this.exampleTargetAttachment}} @attachment={{this.exampleAttachment}} @target="#bwmde">
+    <ModalDialog data-test="my-data-test" @onClose={{action "toggleTargetElement"}} @targetAttachment={{this.exampleTargetAttachment}} @attachment={{this.exampleAttachment}} @target="#bwmde">
       <h1>Stop! Modal Time!</h1>
       <p>Target - Element #bwmde</p>
       <p>Target Attachment: {{this.exampleTargetAttachment}}</p>
@@ -149,7 +149,7 @@
   <CodeSnippet @name="subclass-styles.scss" />
   {{#if this.isShowingSubclassed}}
     {{!-- BEGIN-SNIPPET subclass-modal-dialog --}}
-    <MyCoolModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @translucentOverlay={{true}}>
+    <MyCoolModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingSubclassed) false}} @translucentOverlay={{true}}>
       <h1>Stop! Modal Time!</h1>
       <p>Via Subclass</p>
       <button onclick={{action (mut this.isShowingSubclassed) false}}>Close</button>
@@ -166,7 +166,7 @@
   <CodeSnippet @name="subclass-styles.scss" />
   {{#if this.isShowingSubclassed2}}
     {{!-- BEGIN-SNIPPET subclass-modal-dialog-2 --}}
-    <MyCoolModalDialogTwo @onClose={{action (mut this.isShowingSubclassed2) false}} @translucentOverlay={{true}}>
+    <MyCoolModalDialogTwo data-test="my-data-test" @onClose={{action (mut this.isShowingSubclassed2) false}} @translucentOverlay={{true}}>
       <h1>Stop! Modal Time!</h1>
       <p>Via Subclass</p>
       <button onclick={{action (mut this.isShowingSubclassed2) false}}>Close</button>
@@ -184,7 +184,7 @@
     I AM THE CONTAINER
     {{#if this.isShowingInPlace}}
       {{!-- BEGIN-SNIPPET in-place-modal-dialog --}}
-      <ModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClass="ember-modal-dialog-in-place my-custom-class" @overlayClass="ember-modal-overlay-in-place">
+      <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingInPlace) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClass="ember-modal-dialog-in-place my-custom-class" @overlayClass="ember-modal-overlay-in-place">
         <h1>Stop! Modal Time!</h1>
         <p>In Place</p>
         <button onclick={{action (mut this.isShowingInPlace) false}}>Close</button>
@@ -196,17 +196,17 @@
 
 <div class="example" id="example-in-place-2">
   <h2>In Place</h2>
-  <button onclick={{action (mut this.isShowingInPlace) true}}>Do It</button>
+  <button onclick={{action (mut this.isShowingInPlace2) true}}>Do It</button>
   <CodeSnippet @name="in-place-modal-dialog.hbs" />
   <CodeSnippet @name="in-place.scss" />
   <div id="container-in-place-2">
     I AM THE CONTAINER
-    {{#if this.isShowingInPlace}}
+    {{#if this.isShowingInPlace2}}
       {{!-- BEGIN-SNIPPET in-place-modal-dialog --}}
-      <ModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClassNames="ember-modal-dialog-in-place my-custom-class-2" @overlayClassNames="ember-modal-overlay-in-place">
+      <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingInPlace2) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClassNames="ember-modal-dialog-in-place my-custom-class-2" @overlayClassNames="ember-modal-overlay-in-place">
         <h1>Stop! Modal Time!</h1>
         <p>In Place</p>
-        <button onclick={{action (mut this.isShowingInPlace) false}}>Close</button>
+        <button onclick={{action (mut this.isShowingInPlace2) false}}>Close</button>
       </ModalDialog>
       {{!-- END-SNIPPET --}}
     {{/if}}
@@ -221,7 +221,7 @@
   <div id="container-centered-scrolling">
     {{#if this.isShowingCenteredScrolling}}
       {{!-- BEGIN-SNIPPET centered-scrolling-modal-dialog --}}
-      <ModalDialog @onClose={{action "toggleCenteredScrolling"}} @translucentOverlay={{true}} @targetAttachment="none" @containerClass="centered-scrolling-container" @overlayClass="centered-scrolling-overlay" @wrapperClass="centered-scrolling-wrapper">
+      <ModalDialog data-test="my-data-test" @onClose={{action "toggleCenteredScrolling"}} @translucentOverlay={{true}} @targetAttachment="none" @containerClass="centered-scrolling-container" @overlayClass="centered-scrolling-overlay" @wrapperClass="centered-scrolling-wrapper">
         <h1>Really Long Content To Demonstrate Scrolling</h1>
         <ul>
           <li>Hover over modal and scroll</li>
@@ -243,7 +243,7 @@
   <CodeSnippet @name="element-centered-modal-dialog.hbs" />
   {{#if this.isShowingElementCenterModal}}
     {{!-- BEGIN-SNIPPET element-centered-modal-dialog --}}
-    <ModalDialog @onClose={{action (mut this.isShowingElementCenterModal) false}} @elementId={{this.elementId}} @translucentOverlay={{true}} @targetAttachment="elementCenter" @target="#elementCenter">
+    <ModalDialog data-test="my-data-test" @onClose={{action (mut this.isShowingElementCenterModal) false}} @elementId={{this.elementId}} @translucentOverlay={{true}} @targetAttachment="elementCenter" @target="#elementCenter">
       <p>Centered on element.</p>
     </ModalDialog>
     {{!-- END-SNIPPET --}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -184,7 +184,26 @@
     I AM THE CONTAINER
     {{#if this.isShowingInPlace}}
       {{!-- BEGIN-SNIPPET in-place-modal-dialog --}}
-      <ModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClass="ember-modal-dialog-in-place" @overlayClass="ember-modal-overlay-in-place">
+      <ModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClass="ember-modal-dialog-in-place my-custom-class" @overlayClass="ember-modal-overlay-in-place">
+        <h1>Stop! Modal Time!</h1>
+        <p>In Place</p>
+        <button onclick={{action (mut this.isShowingInPlace) false}}>Close</button>
+      </ModalDialog>
+      {{!-- END-SNIPPET --}}
+    {{/if}}
+  </div>
+</div>
+
+<div class="example" id="example-in-place-2">
+  <h2>In Place</h2>
+  <button onclick={{action (mut this.isShowingInPlace) true}}>Do It</button>
+  <CodeSnippet @name="in-place-modal-dialog.hbs" />
+  <CodeSnippet @name="in-place.scss" />
+  <div id="container-in-place-2">
+    I AM THE CONTAINER
+    {{#if this.isShowingInPlace}}
+      {{!-- BEGIN-SNIPPET in-place-modal-dialog --}}
+      <ModalDialog @onClose={{action (mut this.isShowingSubclassed) false}} @renderInPlace={{true}} @targetAttachment="none" @containerClassNames="ember-modal-dialog-in-place my-custom-class-2" @overlayClassNames="ember-modal-overlay-in-place">
         <h1>Stop! Modal Time!</h1>
         <p>In Place</p>
         <button onclick={{action (mut this.isShowingInPlace) false}}>Close</button>

--- a/tests/helpers/modal-asserts.js
+++ b/tests/helpers/modal-asserts.js
@@ -20,6 +20,11 @@ export default function registerAssertHelpers(assert) {
     return this.dom(selector).isVisible(message);
   };
 
+  assert.hasDataTest = function (selector, dataTest, message) {
+    message = message || `${selector} has data-test attribute`;
+    return this.dom(selector).hasAttribute('data-test', dataTest, message);
+  };
+
   assert.dialogOpensAndCloses = async function (options) {
     const self = this;
     await click(options.openSelector, options.context);


### PR DESCRIPTION
containerClassNames are not passed to the rendered in place modal.
Or rather the property is overriden by the component.

This PR allows us to have rendered in place modals take in the containerClassNames property