### PR TITLE
Avoid Fastboot crash when accessing `navigator` global

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,9 @@ module.exports = {
   env: {
     browser: true,
   },
+  globals: {
+    globalThis: 'readonly',
+  },
   rules: {
     'no-setter-return': 'off',
     'ember/classic-decorator-no-classic-methods': 'warn',

--- a/addon/utils/config-utils.js
+++ b/addon/utils/config-utils.js
@@ -11,7 +11,9 @@ export function getDestinationElementIdFromConfig(config) {
   return modalContainerId;
 }
 
-export const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent);
+export const isIOS =
+  (globalThis.navigator || false) &&
+  /iPad|iPhone|iPod/.test(navigator.userAgent);
 
 export function clickHandlerDelay(component) {
   let ENV = getOwner(component).resolveRegistration('config:environment');


### PR DESCRIPTION
Fixes #399

Would be nice to have a Fastboot test suite but I don't think it needs to block this fix.

I did a naive test by logging the `globalThis` object to make sure it's present in a Fastboot execution – it is.