### PR TITLE
Listed @ember/render-modifiers as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
+    "@ember/render-modifiers": "^2.1.0",
     "@embroider/macros": "^1.0.0",
     "@embroider/util": "^1.0.0",
     "ember-cli-babel": "^7.26.8",
@@ -39,7 +40,6 @@
   "devDependencies": {
     "@ember/jquery": "^2.0.0",
     "@ember/optional-features": "^2.0.0",
-    "@ember/render-modifiers": "^2.1.0",
     "@ember/test-helpers": "^2.6.0",
     "@embroider/test-setup": "^1.0.0",
     "@glimmer/component": "^1.1.2",


### PR DESCRIPTION
## Background

Because `ember-modal-dialog` uses [`{{did-insert}}` and `{{will-destroy}}` modifiers](https://github.com/yapplabs/ember-modal-dialog/blob/v4.1.4/addon/templates/components/overlay.hbs#L5-L6), but didn't list `@ember/render-modifiers` as a dependency, it's possible that a consuming project can run into an error (more so, when that project lists dependencies correctly).

Here's the error message that I got from running a rendering test (`ember-modal-dialog@4.1.3` used):

```sh
Attempted to resolve `did-insert`, which was expected to be a modifier, but nothing was found.
```
