### PR TITLE
Removed {{action}} helper from addon

### DIFF
--- a/addon/components/basic-dialog.hbs
+++ b/addon/components/basic-dialog.hbs
@@ -27,8 +27,8 @@
       {{#if this.hasOverlay}}
         <EmberModalDialog::Overlay
           class={{this.overlayClassNamesString}}
-          @onClickOverlay={{action
-            (ignore-children this.onClickOverlay)
+          @onClickOverlay={{ignore-children
+            this.onClickOverlay
           }}
         >
           <EmberModalDialogPositionedContainer

--- a/addon/components/liquid-dialog.hbs
+++ b/addon/components/liquid-dialog.hbs
@@ -41,9 +41,7 @@
     {{#if this.hasOverlay}}
       <EmberModalDialog::Overlay
         class={{this.overlayClassNamesString}}
-        @onClickOverlay={{action
-          (ignore-children this.onClickOverlay)
-        }}
+        @onClickOverlay={{ignore-children this.onClickOverlay}}
       >
         <div
           class={{this.containerClassNamesString}}

--- a/tests/dummy/app/utils/code-snippets/index.js
+++ b/tests/dummy/app/utils/code-snippets/index.js
@@ -160,7 +160,7 @@ export default class MyCoolModalDialog extends ModalDialogComponent {
 }`,
 
   'subclass-modal-dialog-animatable-hbs': `<MyCoolModalDialog
-  @onClose={{action "toggleSubclassed"}}
+  @onClose={{this.closeModal}}
   @animatable={{true}}
 >
   <h1>Stop! Modal Time!</h1>


### PR DESCRIPTION
## Background

Ember `5.x` [deprecated the `{{action}}` helper](https://deprecations.emberjs.com/id/template-action). By removing the uses in `addon`, we can separate why `ember-release`, `ember-beta`, and `ember-canary` (all now point to `6.x`) currently fail.

I followed the migration guides in the deprecation page:

> Scenario: `action` is passed a function reference
>
> Before:
>
> ```hbs
> <SomeComponent @update={{action this.plusOne}} />
> ```
>
> After:
>
> ```hbs
> <SomeComponent @update={{this.plusOne}} />
> ```

The number of failing tests in `ember-release` is down from 19 to 8, and I believe this PR will be my last one.

<details>

<summary>Before: Test results from <code>ember-release</code> scenario</summary>

```sh
❯ pnpm test:ember-compatibility ember-release --- pnpm test

devDependencies:
- ember-source 5.12.0
+ ember-source 6.0.1-release

not ok 1 Chrome 131.0 - [1686 ms] - Acceptance: modal-dialog | animatable: basic modal
not ok 2 Chrome 131.0 - [1459 ms] - Acceptance: modal-dialog | animatable: modal with translucent overlay
not ok 3 Chrome 131.0 - [362 ms] - Acceptance: modal-dialog | animatable: modal with custom styles
not ok 4 Chrome 131.0 - [1435 ms] - Acceptance: modal-dialog | animatable: subclassed modal
not ok 5 Chrome 131.0 - [1437 ms] - Acceptance: modal-dialog | no animation, no tether: basic modal
not ok 6 Chrome 131.0 - [1443 ms] - Acceptance: modal-dialog | no animation, no tether: modal with translucent overlay
ok 7 Chrome 131.0 - [607 ms] - Acceptance: modal-dialog | no animation, no tether: modal without overlay
not ok 8 Chrome 131.0 - [1561 ms] - Acceptance: modal-dialog | no animation, no tether: modal with overlay
ok 9 Chrome 131.0 - [350 ms] - Acceptance: modal-dialog | no animation, no tether: modal with sibling overlay
not ok 10 Chrome 131.0 - [307 ms] - Acceptance: modal-dialog | no animation, no tether: clicking translucent overlay triggers callback
not ok 11 Chrome 131.0 - [1429 ms] - Acceptance: modal-dialog | no animation, no tether: modal with custom styles
not ok 12 Chrome 131.0 - [1453 ms] - Acceptance: modal-dialog | no animation, no tether: target - selector
not ok 13 Chrome 131.0 - [1449 ms] - Acceptance: modal-dialog | no animation, no tether: target - element
not ok 14 Chrome 131.0 - [1435 ms] - Acceptance: modal-dialog | no animation, no tether: subclassed modal
not ok 15 Chrome 131.0 - [1433 ms] - Acceptance: modal-dialog | no animation, no tether: subclassed modal with string for containerClassNames
ok 16 Chrome 131.0 - [352 ms] - Acceptance: modal-dialog | no animation, no tether: in place
not ok 17 Chrome 131.0 - [291 ms] - Acceptance: modal-dialog | tethered and animatable: target - selector
not ok 18 Chrome 131.0 - [258 ms] - Acceptance: modal-dialog | tethered and animatable: target - element
ok 19 Chrome 131.0 - [136 ms] - Acceptance: modal-dialog | tethered: target - selector
ok 20 Chrome 131.0 - [126 ms] - Acceptance: modal-dialog | tethered: target - element
ok 21 Chrome 131.0 - [41 ms] - Integration | Component | ember-modal-dialog-positioned-container: it renders
not ok 22 Chrome 131.0 - [40 ms] - Integration | Component | ember-modal-dialog/-basic-dialog: it renders
ok 23 Chrome 131.0 - [38 ms] - Integration | Component | ember-modal-dialog/-in-place-dialog: it renders
not ok 24 Chrome 131.0 - [38 ms] - Integration | Component | ember-modal-dialog/-liquid-dialog: it renders
not ok 25 Chrome 131.0 - [41 ms] - Integration | Component | ember-modal-dialog/-liquid-tether-dialog: it renders
ok 26 Chrome 131.0 - [40 ms] - Integration | Component | ember-modal-dialog/-tether-dialog: it renders
ok 27 Chrome 131.0 - [39 ms] - Integration | Component | ember-modal-dialog/overlay: it renders
not ok 28 Chrome 131.0 - [38 ms] - Integration | Component | modal-dialog: it renders
ok 29 Chrome 131.0 - [15 ms] - Unit | Service | modal dialog: it knows the destinationElementId
ok 30 Chrome 131.0 - [0 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..30
# tests 30
# pass  11
# skip  0
# todo  0
# fail  19
```

</details>

<details>

<summary>After: Test results from <code>ember-release</code> scenario</summary>

```sh
❯ pnpm test:ember-compatibility ember-release --- pnpm test

devDependencies:
- ember-source 5.12.0
+ ember-source 6.0.1-release

not ok 1 Chrome 131.0 - [1757 ms] - Acceptance: modal-dialog | animatable: basic modal
not ok 2 Chrome 131.0 - [1457 ms] - Acceptance: modal-dialog | animatable: modal with translucent overlay
not ok 3 Chrome 131.0 - [364 ms] - Acceptance: modal-dialog | animatable: modal with custom styles
not ok 4 Chrome 131.0 - [332 ms] - Acceptance: modal-dialog | animatable: subclassed modal
ok 5 Chrome 131.0 - [354 ms] - Acceptance: modal-dialog | no animation, no tether: basic modal
ok 6 Chrome 131.0 - [353 ms] - Acceptance: modal-dialog | no animation, no tether: modal with translucent overlay
ok 7 Chrome 131.0 - [355 ms] - Acceptance: modal-dialog | no animation, no tether: modal without overlay
ok 8 Chrome 131.0 - [539 ms] - Acceptance: modal-dialog | no animation, no tether: modal with overlay
ok 9 Chrome 131.0 - [469 ms] - Acceptance: modal-dialog | no animation, no tether: modal with sibling overlay
ok 10 Chrome 131.0 - [483 ms] - Acceptance: modal-dialog | no animation, no tether: clicking translucent overlay triggers callback
ok 11 Chrome 131.0 - [387 ms] - Acceptance: modal-dialog | no animation, no tether: modal with custom styles
ok 12 Chrome 131.0 - [318 ms] - Acceptance: modal-dialog | no animation, no tether: target - selector
ok 13 Chrome 131.0 - [318 ms] - Acceptance: modal-dialog | no animation, no tether: target - element
ok 14 Chrome 131.0 - [324 ms] - Acceptance: modal-dialog | no animation, no tether: subclassed modal
ok 15 Chrome 131.0 - [316 ms] - Acceptance: modal-dialog | no animation, no tether: subclassed modal with string for containerClassNames
ok 16 Chrome 131.0 - [322 ms] - Acceptance: modal-dialog | no animation, no tether: in place
not ok 17 Chrome 131.0 - [263 ms] - Acceptance: modal-dialog | tethered and animatable: target - selector
not ok 18 Chrome 131.0 - [260 ms] - Acceptance: modal-dialog | tethered and animatable: target - element
ok 19 Chrome 131.0 - [129 ms] - Acceptance: modal-dialog | tethered: target - selector
ok 20 Chrome 131.0 - [134 ms] - Acceptance: modal-dialog | tethered: target - element
ok 21 Chrome 131.0 - [41 ms] - Integration | Component | ember-modal-dialog-positioned-container: it renders
ok 22 Chrome 131.0 - [41 ms] - Integration | Component | ember-modal-dialog/-basic-dialog: it renders
ok 23 Chrome 131.0 - [41 ms] - Integration | Component | ember-modal-dialog/-in-place-dialog: it renders
not ok 24 Chrome 131.0 - [39 ms] - Integration | Component | ember-modal-dialog/-liquid-dialog: it renders
not ok 25 Chrome 131.0 - [39 ms] - Integration | Component | ember-modal-dialog/-liquid-tether-dialog: it renders
ok 26 Chrome 131.0 - [39 ms] - Integration | Component | ember-modal-dialog/-tether-dialog: it renders
ok 27 Chrome 131.0 - [40 ms] - Integration | Component | ember-modal-dialog/overlay: it renders
ok 28 Chrome 131.0 - [41 ms] - Integration | Component | modal-dialog: it renders
ok 29 Chrome 131.0 - [14 ms] - Unit | Service | modal dialog: it knows the destinationElementId
ok 30 Chrome 131.0 - [0 ms] - ember-qunit: Ember.onerror validation: Ember.onerror is functioning properly

1..30
# tests 30
# pass  22
# skip  0
# todo  0
# fail  8
```

</details>

The remaining 8 failing tests are due to [`liquid-fire@0.34.0` being used](https://github.com/ember-animation/liquid-fire/blob/v0.34.0/addon/templates/components/liquid-versions.hbs#L5) in these tests ([`0.37.0` is said to have removed `{{action}}` helpers](https://github.com/ember-animation/liquid-fire/releases/tag/v0.37.0)).

If we were to release a patch version after this PR, my guess is: As long as a consumer doesn't use the `-liquid-dialog` or `-liquid-tether-dialog` component, `ember-modal-dialog` will no longer be a blocker for updating `ember-source` to `6.0.0`. (The consumer may also be able to find the right combinations of `liquid-*` package versions that I didn't.)
